### PR TITLE
Ci configuration travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,11 @@ install:
   - pip install -r requirements.txt
   - pip install coveralls
 
+before_script:
+  mv django/santropolFeast/santropolFeast/settings_test.py django/santropolFeast/santropolFeast/settings.py
+
 script:
   coverage run --omit=*.virtualenvs*,*virtualenv* django/santropolFeast/manage.py test
+
 after_success:
   coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+
+python:
+  - 3.5
+
+install:
+  - pip install -r requirements.txt
+  - pip install coveralls
+
+script:
+  coverage run --omit=*.virtualenvs*,*virtualenv* django/santropolFeast/manage.py test
+after_success:
+  coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,14 @@ python:
 install:
   - pip install -r requirements.txt
   - pip install coveralls
+  - pip install pep8
 
 before_script:
-  mv django/santropolFeast/santropolFeast/settings_test.py django/santropolFeast/santropolFeast/settings.py
+  - mv django/santropolFeast/santropolFeast/settings_test.py django/santropolFeast/santropolFeast/settings.py
 
 script:
-  coverage run --omit=*.virtualenvs*,*virtualenv* django/santropolFeast/manage.py test
+  - coverage run --omit=*.virtualenvs*,*virtualenv* django/santropolFeast/manage.py test
+  - pep8 --count --show-source django/santropolFeast/
 
 after_success:
-  coveralls
+  - coveralls

--- a/django/santropolFeast/santropolFeast/settings_test.py
+++ b/django/santropolFeast/santropolFeast/settings_test.py
@@ -1,0 +1,13 @@
+SECRET_KEY = "SecretKeyForUseOnTravis"
+DEBUG = False
+TEMPLATE_DEBUG = True
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': '',
+        'USER': '',
+        'PASSWORD': '',
+        'HOST': '',
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Django
-mysqlclient
+django==1.9.2
+mysqlclient==1.3.7


### PR DESCRIPTION
### Related issues : #12 

**I've not access to the organization of Savoir Faire Linux, so please to do last step of configuration listed here**

With this PR the project:

- test standard PEP8
- test unit test of django
- send information to coveralls

For works you need :

1. Go on https://travis-ci.org/
2. Sign-in with github and allow travis to access to your public data (and to the organization data)
3. Add the repository santropol-feast to the list of repository managed by travis.
4. Go on https://coveralls.io/
5. Sign-in with github and allow coveralls to access to your public data (and to the organization data)
6. Add the repository santropol-feast to the list of repository managed by coveralls.
7. Accept this PR to test the continious integrations with Travis and Coveralls.

**This configuration is not sure for the moment, we need to write tests to try it.** 
I've just try pep8 and the continious integrations to coveralls.
