### PR TITLE
Fixed inline diagram image in docs/data_model/README.md

### DIFF
--- a/docs/data_model/README.md
+++ b/docs/data_model/README.md
@@ -1,3 +1,3 @@
 # Data Model (current)
 
-[![Data model image UML](http://www.plantuml.com/plantuml/proxy?fmt=svg&src=https://raw.githubusercontent.com/savoirfairelinux/santropol-feast/dev/docs/data_model/current_data_model.uml)
+![Data model image PNG](https://raw.githubusercontent.com/savoirfairelinux/santropol-feast/dev/docs/data_model/current_data_model.png)


### PR DESCRIPTION
The dynamic generation of the diagram .png image (by passing the .uml file to the plantuml server) does not work on Github, although it works on http://markdownlivepreview.com/.

Now the README.md shows inline the .png which is in the same folder.