### PR TITLE
Used datetime.date.today as a default value for the Referencing.date field.

### DIFF
--- a/django/santropolFeast/member/migrations/0020_auto_20160526_2345.py
+++ b/django/santropolFeast/member/migrations/0020_auto_20160526_2345.py
@@ -1,0 +1,19 @@
+from __future__ import unicode_literals
+
+import datetime
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('member', '0019_auto_20160525_1708'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='referencing',
+            name='date',
+            field=models.DateField(default=datetime.date.today, verbose_name='Referral date'),
+        ),
+    ]

--- a/django/santropolFeast/member/models.py
+++ b/django/santropolFeast/member/models.py
@@ -299,7 +299,7 @@ class Referencing (models.Model):
 
     date = models.DateField(verbose_name=_("Referral date"),
                             auto_now=False, auto_now_add=False,
-                            default=datetime.date.today())
+                            default=datetime.date.today)
 
     def __str__(self):
         return "{} {} referred {} {} on {}".format(


### PR DESCRIPTION
### Changes proposed in this pull request:

Used datetime.date.today as a default value for the Referencing.date field.

### Status

Ready

### Deployment notes and migration

Migration needed (with no resulting schema change)

Using `datetime.date.today()` was setting the default value to the date the server
process was started and also triggered a migration state change every day.

This will silence the fields.W161 check warning.