### PR TITLE
Fix issue 158: put 'Add Client' button on client list page

### DIFF
--- a/django/santropolFeast/member/templates/client/filter_list.html
+++ b/django/santropolFeast/member/templates/client/filter_list.html
@@ -14,14 +14,24 @@
 
 <h1>Search client</h1>
 
-<form action="" method="get">
-    <div class="ui large action left icon input">
-        <i class="users icon"></i>
-        {{ filter.form.member__lastname }}
-        <button class="ui teal button" type="submit">Search
-        </button>
-    </div>
-</form>
+<div class="ui mobile reversed equal width grid">
+  <div class="column">
+
+    <form action="" method="get">
+        <div class="ui large action left icon input">
+            <i class="users icon"></i>
+            {{ filter.form.member__lastname }}
+            <button class="ui teal button" type="submit">Search
+            </button>
+        </div>
+    </form>
+
+  </div>
+  <div class="column">
+    <a class="large ui button" href="{% url 'member:member_step' %}">Add new client</a>
+  </div>
+</div>
+
 
 <table class="ui very basic table">
   <thead>


### PR DESCRIPTION
*Fixes # .*

### Changes proposed in this pull request:
Add client button to client list page.
Added a grid to place client button to right of client search.

### Status

- [X] READY
- [] HOLD
- [] WIP (Work-In-Progress)

### Deployment notes and migration

- [] Migration needed

Fill me in ...

@savoirfairelinux/mll

