### PR TITLE
[WIP] Add skeleton models for the weekdays delivery for ongoing client

### DIFF
--- a/django/santropolFeast/member/models.py
+++ b/django/santropolFeast/member/models.py
@@ -240,6 +240,12 @@ class Client(models.Model):
         default=PENDING
     )
 
+    delivery_days = models.ManyToManyField(
+        'member.WeekDay',
+        related_name='ongoing_member_delivery_days',
+        blank=True
+    )
+
     restrictions = models.ManyToManyField(
         'meal.Ingredient',
         related_name='restricted_clients',
@@ -273,6 +279,15 @@ class ClientFilter(django_filters.FilterSet):
 
     class Meta:
         model = Client
+
+
+class WeekDay(models.Model):
+    class Meta:
+        verbose_name_plural = _('weekdays')
+
+    name = models.CharField(
+        max_length=50,
+    )
 
 
 class Referencing (models.Model):


### PR DESCRIPTION

### Changes proposed in this pull request:

* Many to many fields for which day an ongoing client received his meal

### Status

- [] READY
- [] HOLD
- [X] WIP (Work-In-Progress)

### Deployment notes and migration

- [ X ] Migration needed


@savoirfairelinux/mll

The skeleton models for the delivery days is a ManyToMany