### PR TITLE
add requirements for django-webtest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ mysqlclient==1.3.7
 factory_boy==2.7.0
 django-formtools==1.0
 django-filter==0.13.0
+django-webtest==1.7.9


### PR DESCRIPTION

### Changes proposed in this pull request:

* add requirement for webtest to help with testing the html rendering to client

### Status

- [ ] READY
- [ ] HOLD
- [X] WIP (Work-In-Progress)



@savoirfairelinux/mll

