### PR TITLE
coverage calculation must include tests of all apps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,7 @@ install:
   - pip install pep8
 
 script:
-  - coverage run --omit=*.virtualenvs*,*virtualenv* django/santropolFeast/manage.py test --settings=santropolFeast.settings_test member
-  - coverage run --omit=*.virtualenvs*,*virtualenv* django/santropolFeast/manage.py test --settings=santropolFeast.settings_test meal
-  - coverage run --omit=*.virtualenvs*,*virtualenv* django/santropolFeast/manage.py test --settings=santropolFeast.settings_test order
-  - coverage run --omit=*.virtualenvs*,*virtualenv* django/santropolFeast/manage.py test --settings=santropolFeast.settings_test notification
+  - coverage run --omit=*.virtualenvs*,*virtualenv* django/santropolFeast/manage.py test --settings=santropolFeast.settings_test member meal order notification
   - pep8 --count --show-source --exclude=migrations django/santropolFeast/
 
 after_success:


### PR DESCRIPTION
*Fixes # 234.*

### Changes proposed in this pull request:

* .travis.yml : coverage in one line for all apps. See solution (b) in explanation for issue https://github.com/savoirfairelinux/santropol-feast/issues/234

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### Deployment notes and migration

- [ ] Migration needed



@savoirfairelinux/mll

