### PR TITLE
Fix 234 Coverage calculation + Fix004c Kitchen Count Report View PoC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - pip install pep8
 
 script:
-  - coverage run --omit=*.virtualenvs*,*virtualenv* django/santropolFeast/manage.py test --settings=santropolFeast.settings_test member meal order notification
+  - coverage run --omit=*.virtualenvs*,*virtualenv* django/santropolFeast/manage.py test --settings=santropolFeast.settings_test member meal order notification delivery
   - pep8 --count --show-source --exclude=migrations django/santropolFeast/
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,7 @@ install:
   - pip install pep8
 
 script:
-  - coverage run --omit=*.virtualenvs*,*virtualenv* django/santropolFeast/manage.py test --settings=santropolFeast.settings_test member
-  - coverage run --omit=*.virtualenvs*,*virtualenv* django/santropolFeast/manage.py test --settings=santropolFeast.settings_test meal
-  - coverage run --omit=*.virtualenvs*,*virtualenv* django/santropolFeast/manage.py test --settings=santropolFeast.settings_test order
-  - coverage run --omit=*.virtualenvs*,*virtualenv* django/santropolFeast/manage.py test --settings=santropolFeast.settings_test notification
+  - coverage run --omit=*.virtualenvs*,*virtualenv* django/santropolFeast/manage.py test --settings=santropolFeast.settings_test member meal order notification
   - pep8 --count --show-source --exclude=migrations django/santropolFeast/
 
 after_success:

--- a/django/santropolFeast/dataexec.py
+++ b/django/santropolFeast/dataexec.py
@@ -1,0 +1,15 @@
+# usage : python dataexec.py [santropolFeast.settingsSPECIAL]
+import os
+import sys
+
+
+def run():
+    if len(sys.argv) > 1:
+        settings = sys.argv[1]
+    else:
+        settings = 'santropolFeast.settings'
+    os.environ['DJANGO_SETTINGS_MODULE'] = settings
+    import django
+    django.setup()
+    import dataload
+run()

--- a/django/santropolFeast/dataload.py
+++ b/django/santropolFeast/dataload.py
@@ -1,0 +1,752 @@
+# -*- coding: utf-8 -*-
+import aldjemy.core as ac
+from sqlalchemy.orm import sessionmaker, aliased
+from sqlalchemy import func, or_, and_
+
+import datetime
+import io
+import sys
+
+from meal.models import Component, Restricted_item, Ingredient
+from meal.models import Component_ingredient, Incompatibility
+from meal.models import Menu, Menu_component
+from member.models import Member, Client, Contact, Address, Note, Referencing
+from member.models import Route, Note, Option, Client_option, Restriction
+from member.models import Client_avoid_ingredient, Client_avoid_component
+from notification.models import Notification
+from order.models import Order, Order_item
+
+
+def print_all_cols(q):
+    pass
+    # print("\n---------------------------------------------------------\n", q)
+    # for row in q:
+    #     d = row.__dict__
+    #     # filter out SQLAlchemy "internal" columns to get "result" dict
+    #     fd = { k:v for (k,v) in d.items()
+    #            if not str(k).startswith("_") }
+    #     print("Row ", fd)
+
+
+def print_rows(q, heading=""):
+    pass
+    # print("\n-----------------------------------------------------\n",
+    #       # q, "\n",
+    #       heading)
+    # for row in q.all():
+    #     print(row)
+
+
+def run():
+    print("START dataload")
+    engine = ac.get_engine()
+    Session = sessionmaker(bind=engine)
+    db = Session()
+
+    # meal app
+    Ingredient.objects.all().delete()
+    Component.objects.all().delete()
+    Component_ingredient.objects.all().delete()
+    Restricted_item.objects.all().delete()
+    Incompatibility.objects.all().delete()
+    Menu.objects.all().delete()
+    Menu_component.objects.all().delete()
+
+    # member app
+    Member.objects.all().delete()
+    Address.objects.all().delete()
+    Contact.objects.all().delete()
+    Client.objects.all().delete()
+    Referencing.objects.all().delete()
+    Note.objects.all().delete()
+    Option.objects.all().delete()
+    Client_option.objects.all().delete()
+    Restriction.objects.all().delete()
+    Client_avoid_ingredient.objects.all().delete()
+    Client_avoid_component.objects.all().delete()
+    Route.objects.all().delete()
+
+    # notification app
+    Notification.objects.all().delete()
+
+    # order app
+    Order.objects.all().delete()
+    Order_item.objects.all().delete()
+
+    # --------------------------------------------------------------------------
+
+    ing_1 = Ingredient(
+        name='Onion',
+        ingredient_group='veggies and fruits')
+    ing_1.save()
+    ing_2 = Ingredient(
+        name='Pepper',
+        ingredient_group='spices')
+    ing_2.save()
+    ing_3 = Ingredient(
+        name='Ground porc',
+        ingredient_group='meat')
+    ing_3.save()
+    ing_4 = Ingredient(
+        name='Ground beef',
+        ingredient_group='meat')
+    ing_4.save()
+    ing_5 = Ingredient(
+        name='Chicken thighs',
+        ingredient_group='meat')
+    ing_5.save()
+    ing_6 = Ingredient(
+        name='Turkey thighs',
+        ingredient_group='meat')
+    ing_6.save()
+    ing_7 = Ingredient(
+        name='Porc toulouse sausage',
+        ingredient_group='meat')
+    ing_7.save()
+    ing_8 = Ingredient(
+        name='Beef cubes',
+        ingredient_group='meat')
+    ing_8.save()
+    ing_9 = Ingredient(
+        name='Lamb cubes',
+        ingredient_group='meat')
+    ing_9.save()
+    ing_10 = Ingredient(
+        name='Ham',
+        ingredient_group='meat')
+    ing_10.save()
+    ing_11 = Ingredient(
+        name='Pork cubes',
+        ingredient_group='meat')
+    ing_11.save()
+    ing_12 = Ingredient(
+        name='Cheese : Feta',
+        ingredient_group='dairy')
+    ing_12.save()
+    ing_13 = Ingredient(
+        name='Cheese : Cheddar',
+        ingredient_group='dairy')
+    ing_13.save()
+    ing_14 = Ingredient(
+        name='Cheese : Parmesan',
+        ingredient_group='dairy')
+    ing_14.save()
+    ing_15 = Ingredient(
+        name='Cheese : Blue cheese',
+        ingredient_group='dairy')
+    ing_15.save()
+    ing_16 = Ingredient(
+        name='Cheese : Mozzarella',
+        ingredient_group='dairy')
+    ing_16.save()
+    ing_17 = Ingredient(
+        name='Cheese : Bocconcini',
+        ingredient_group='dairy')
+    ing_17.save()
+    ing_18 = Ingredient(
+        name='Cheese : Ricotta',
+        ingredient_group='dairy')
+    ing_18.save()
+    ing_19 = Ingredient(
+        name='Cheese : Cottage cheese',
+        ingredient_group='dairy')
+    ing_19.save()
+    ing_20 = Ingredient(
+        name='Milk',
+        ingredient_group='dairy')
+    ing_20.save()
+    ing_21 = Ingredient(
+        name='Lactose-free milk',
+        ingredient_group='dairy')
+    ing_21.save()
+    ing_22 = Ingredient(
+        name='Butter',
+        ingredient_group='dairy')
+    ing_22.save()
+    ing_23 = Ingredient(
+        name='soy sauce',
+        ingredient_group='oils and sauces')
+    ing_23.save()
+    ing_24 = Ingredient(
+        name='green peppers',
+        ingredient_group='veggies and fruits')
+    ing_24.save()
+    ing_25 = Ingredient(
+        name='sesame seeds',
+        ingredient_group='dry and canned goods')
+    ing_25.save()
+    #
+    print_all_cols(db.query(Ingredient.sa))
+    print_rows(Ingredient.objects)
+    # -----------------------------------------------------------------------------
+    com_1 = Component(
+        name='Coq au vin',
+        component_group='main dish')
+    com_1.save()
+    com_2 = Component(
+        name='Meat pie',
+        component_group='main dish')
+    com_2.save()
+    com_3 = Component(
+        name='Vegetable fried rice',
+        component_group='main dish')
+    com_3.save()
+    com_4 = Component(
+        name='Sausage cassoulet',
+        component_group='main dish')
+    com_4.save()
+    com_5 = Component(
+        name='Fish chowder',
+        component_group='main dish')
+    com_5.save()
+    com_6 = Component(
+        name='Ginger pork',
+        component_group='main dish')
+    com_6.save()
+    com_7 = Component(
+        name='Beef Meatloaf',
+        component_group='main dish')
+    com_7.save()
+    com_8 = Component(
+        name='Day s Dessert',
+        component_group='dessert')
+    com_8.save()
+    com_9 = Component(
+        name='Day s Diabetic Dessert',
+        component_group='diabetic dessert')
+    com_9.save()
+    com_10 = Component(
+        name='Fruit Salad',
+        component_group='fruit salad')
+    com_10.save()
+    com_11 = Component(
+        name='Green Salad',
+        component_group='green salad')
+    com_11.save()
+    com_12 = Component(
+        name='Pudding',
+        component_group='pudding')
+    com_12.save()
+    #
+    print_all_cols(db.query(Component.sa))
+    print_rows(Component.objects)
+
+    # -----------------------------------------------------------------------------
+    com_ing_1 = Component_ingredient(
+        component=com_6, ingredient=ing_3)
+    com_ing_1.save()
+    com_ing_2 = Component_ingredient(
+        component=com_6, ingredient=ing_23)
+    com_ing_2.save()
+    com_ing_3 = Component_ingredient(
+        component=com_6, ingredient=ing_24)
+    com_ing_3.save()
+    com_ing_4 = Component_ingredient(
+        component=com_6, ingredient=ing_25)
+    com_ing_4.save()
+    com_ing_5 = Component_ingredient(
+        component=com_6, ingredient=ing_1)
+    com_ing_5.save()
+    #
+    print_all_cols(db.query(Component_ingredient.sa))
+    print_rows(Component_ingredient.objects)
+
+    # -----------------------------------------------------------------------------
+    ri_1 = Restricted_item(
+        name='onion',
+        restricted_item_group='vegetables',
+        description='')
+    ri_1.save()
+    ri_2 = Restricted_item(
+        name='pork',
+        restricted_item_group='veggies and fruits',
+        description='')
+    ri_2.save()
+    ri_3 = Restricted_item(
+        name='soya',
+        restricted_item_group='other',
+        description='')
+    ri_3.save()
+    ri_4 = Restricted_item(
+        name='soy sauce',
+        restricted_item_group='other',
+        description='gluten, salt')
+    ri_4.save()
+    ri_5 = Restricted_item(
+        name='seeds',
+        restricted_item_group='veggies and fruits',
+        description='text')
+    ri_5.save()
+    ri_6 = Restricted_item(
+        name='sesame',
+        restricted_item_group='veggies and fruits',
+        description='text')
+    ri_6.save()
+    ri_7 = Restricted_item(
+        name='green veggies',
+        restricted_item_group='veggies and fruits',
+        description='text')
+    ri_7.save()
+    ri_8 = Restricted_item(
+        name='brussel sprouts',
+        restricted_item_group='veggies and fruits',
+        description='text')
+    ri_8.save()
+    #
+    print_all_cols(db.query(Restricted_item.sa))
+    print_rows(Restricted_item.objects)
+
+    # -----------------------------------------------------------------------------
+    inc_1 = Incompatibility(
+        restricted_item=ri_1, ingredient=ing_1)
+    inc_1.save()
+    inc_2 = Incompatibility(
+        restricted_item=ri_2, ingredient=ing_3)
+    inc_2.save()
+    inc_3 = Incompatibility(
+        restricted_item=ri_3, ingredient=ing_23)
+    inc_3.save()
+    inc_4 = Incompatibility(
+        restricted_item=ri_4, ingredient=ing_23)
+    inc_4.save()
+    inc_5 = Incompatibility(
+        restricted_item=ri_5, ingredient=ing_25)
+    inc_5.save()
+    inc_6 = Incompatibility(
+        restricted_item=ri_6, ingredient=ing_25)
+    inc_6.save()
+    #
+    print_all_cols(db.query(Incompatibility.sa))
+    print_rows(Incompatibility.objects)
+    # -----------------------------------------------------------------------------
+    men_1 = Menu(
+        date=datetime.date(2016, 5, 21))
+    men_1.save()
+    men_2 = Menu(
+        date=datetime.date(2016, 5, 28))
+    men_2.save()
+    #
+    print_all_cols(db.query(Menu.sa))
+    print_rows(Menu.objects)
+    # -----------------------------------------------------------------------------
+    men_com_1 = Menu_component(
+        component=com_6, menu=men_1)
+    men_com_1.save()
+    men_com_1 = Menu_component(
+        component=com_7, menu=men_2)
+    men_com_1.save()
+    #
+    print_all_cols(db.query(Menu_component.sa))
+    print_rows(Menu_component.objects)
+
+    # -----------------------------------------------------------------------------
+    add_1 = Address(
+        number=2444,
+        street='Des Perdrix',
+        apartment='407',
+        floor=10,
+        city='Montreal',
+        postal_code='H1A2B3')
+    add_1.save()
+    add_2 = Address(
+        number=1244,
+        street='Des Hirondelles',
+        apartment='4',
+        city='Montreal',
+        postal_code='H3D4G6')
+    add_2.save()
+    add_3 = Address(
+        number=543,
+        street='Des Éperviers',
+        apartment='',
+        city='Montreal',
+        postal_code='H4E3WS')
+    add_3.save()
+    add_4 = Address(
+        number=6543,
+        street='Des Moineaux',
+        apartment='1',
+        city='Montreal',
+        postal_code='H5R7H8')
+    add_4.save()
+    #
+    print_all_cols(db.query(Address.sa))
+    print_rows(Address.objects)
+
+    # -----------------------------------------------------------------------------
+    mem_1 = Member(
+        firstname='John',
+        lastname='Doe',
+        address=add_1)
+    mem_1.save()
+    mem_2 = Member(
+        firstname='Louise',
+        lastname='Dallaire',
+        address=add_2)
+    mem_2.save()
+    mem_3 = Member(
+        firstname='Paul',
+        lastname='Taylor',
+        address=add_4)
+    mem_3.save()
+    mem_4 = Member(
+        firstname='Peter',
+        lastname='Murray',
+        address=add_3)
+    mem_4.save()
+    mem_5 = Member(
+        firstname='Dr. Lucie',
+        lastname='Tremblay')
+    mem_5.save()
+    mem_6 = Member(
+        firstname='Dr. Mary',
+        lastname='Johnson')
+    mem_6.save()
+    #
+    print_all_cols(db.query(Member.sa))
+    print_rows(Member.objects)
+
+    # -----------------------------------------------------------------------------
+    con_1 = Contact(
+        member=mem_1,
+        type='Home phone',
+        value='514-345-6789')
+    con_1.save()
+    con_2 = Contact(
+        member=mem_2,
+        type='Cell phone',
+        value='438-234-4567')
+    con_2.save()
+    con_3 = Contact(
+        member=mem_4,
+        type='Home phone',
+        value='514-654-1289')
+    con_3.save()
+    #
+    print_all_cols(db.query(Contact.sa))
+    print_rows(Contact.objects)
+
+    # -----------------------------------------------------------------------------
+    cli_1 = Client(
+        member=mem_1,
+        billing_member=mem_2,
+        emergency_contact=mem_3,
+        billing_payment_type='check',
+        rate_type='Low income',
+        emergency_contact_relationship='Nephew',
+        status='A',
+        language='en',
+        alert='',
+        delivery_type='O',
+        gender='M',
+        birthdate=datetime.date(1940, 2, 23))
+    cli_1.save()
+    cli_2 = Client(
+        member=mem_4,
+        billing_member=mem_4,
+        billing_payment_type='check',
+        rate_type='Low income',
+        emergency_contact_relationship='',
+        status='A',
+        language='en',
+        alert='',
+        delivery_type='O',
+        gender='M',
+        birthdate=datetime.date(1945, 12, 13))
+    cli_2.save()
+    cli_3 = Client(
+        member=mem_2,
+        billing_member=mem_2,
+        billing_payment_type='check',
+        rate_type='Low income',
+        emergency_contact_relationship='',
+        status='A',
+        language='en',
+        alert='',
+        delivery_type='O',
+        gender='M',
+        birthdate=datetime.date(1943, 12, 13))
+    cli_3.save()
+    cli_4 = Client(
+        member=mem_3,
+        billing_member=mem_3,
+        billing_payment_type='check',
+        rate_type='Low income',
+        emergency_contact_relationship='',
+        status='A',
+        language='en',
+        alert='',
+        delivery_type='O',
+        gender='M',
+        birthdate=datetime.date(1943, 12, 13))
+    cli_4.save()
+    #
+    print_all_cols(db.query(Client.sa))
+    print_rows(Client.objects)
+
+    # -----------------------------------------------------------------------------
+    ref_1 = Referencing(
+        referent=mem_5,
+        client=cli_1,
+        referral_reason='Can hardly walk.',
+        work_information='CHUM Hôtel-Dieu',
+        date=datetime.date(2015, 11, 2))
+    ref_1.save()
+    ref_2 = Referencing(
+        referent=mem_6,
+        client=cli_2,
+        referral_reason='Had an operation.',
+        work_information='CUSM',
+        date=datetime.date(2014, 1, 12))
+    ref_2.save()
+    #
+    print_all_cols(db.query(Referencing.sa))
+    print_rows(Referencing.objects)
+
+    # -----------------------------------------------------------------------------
+    opt_1 = Option(
+        name='Fruit Salad',
+        option_group='side dish',
+        description='')
+    opt_1.save()
+    opt_2 = Option(
+        name='Green Salad',
+        option_group='side dish',
+        description='')
+    opt_2.save()
+    opt_3 = Option(
+        name='Dessert',
+        option_group='side dish',
+        description='')
+    opt_3.save()
+    opt_4 = Option(
+        name='Pudding',
+        option_group='side dish',
+        description='')
+    opt_4.save()
+    opt_5 = Option(
+        name='Diabetic dessert',
+        option_group='side dish',
+        description='')
+    opt_5.save()
+    opt_6 = Option(
+        name='Puree all',
+        option_group='preparation',
+        description='')
+    opt_6.save()
+    opt_7 = Option(
+        name='Cut up meat',
+        option_group='preparation',
+        description='')
+    opt_7.save()
+    #
+    print_all_cols(db.query(Referencing.sa))
+    print_rows(Referencing.objects)
+
+    # -----------------------------------------------------------------------------
+    cli_opt_1 = Client_option(
+        client=cli_1,
+        option=opt_6)
+    cli_opt_1.save()
+    cli_opt_2 = Client_option(
+        client=cli_1,
+        option=opt_4)
+    cli_opt_2.save()
+    cli_opt_3 = Client_option(
+        client=cli_2,
+        option=opt_3)
+    cli_opt_3.save()
+    cli_opt_4 = Client_option(
+        client=cli_3,
+        option=opt_7)
+    cli_opt_4.save()
+    #
+    print_all_cols(db.query(Client_option.sa))
+    print_rows(Client_option.objects)
+
+    # -----------------------------------------------------------------------------
+    res_1 = Restriction(
+        client=cli_1,
+        restricted_item=ri_4)
+    res_1.save()
+    res_2 = Restriction(
+        client=cli_1,
+        restricted_item=ri_2)
+    res_2.save()
+    res_3 = Restriction(
+        client=cli_1,
+        restricted_item=ri_8)
+    res_3.save()
+    #
+    print_all_cols(db.query(Restriction.sa))
+    print_rows(Restriction.objects)
+
+    # -----------------------------------------------------------------------------
+    cai_1 = Client_avoid_ingredient(
+        client=cli_4,
+        ingredient=ing_1)
+    cai_1.save()
+    cai_2 = Client_avoid_ingredient(
+        client=cli_4,
+        ingredient=ing_10)
+    cai_2.save()
+    cai_3 = Client_avoid_ingredient(
+        client=cli_4,
+        ingredient=ing_3)
+    cai_3.save()
+    #
+    print_all_cols(db.query(Client_avoid_ingredient.sa))
+    print_rows(Client_avoid_ingredient.objects)
+
+    # -----------------------------------------------------------------------------
+    cac_1 = Client_avoid_component(
+        client=cli_4,
+        component=com_1)
+    cac_1.save()
+    cac_2 = Client_avoid_component(
+        client=cli_4,
+        component=com_7)
+    cac_2.save()
+    cac_3 = Client_avoid_component(
+        client=cli_4,
+        component=com_3)
+    cac_3.save()
+    #
+    print_all_cols(db.query(Client_avoid_component.sa))
+    print_rows(Client_avoid_component.objects)
+
+    # -----------------------------------------------------------------------------
+    ord_1 = Order(
+        client=cli_1,
+        creation_date=datetime.date(2016, 5, 20),
+        delivery_date=datetime.date(2016, 5, 21),
+        status='O')
+    ord_1.save()
+    ord_2 = Order(
+        client=cli_2,
+        creation_date=datetime.date(2016, 5, 20),
+        delivery_date=datetime.date(2016, 5, 21),
+        status='O')
+    ord_2.save()
+    ord_3 = Order(
+        client=cli_3,
+        creation_date=datetime.date(2016, 5, 20),
+        delivery_date=datetime.date(2016, 5, 21),
+        status='O')
+    ord_3.save()
+    ord_4 = Order(
+        client=cli_4,
+        creation_date=datetime.date(2016, 5, 20),
+        delivery_date=datetime.date(2016, 5, 21),
+        status='O')
+    ord_4.save()
+    #
+    print_all_cols(db.query(Order.sa))
+    print_rows(Order.objects)
+
+    # -----------------------------------------------------------------------------
+    oi_1 = Order_item(
+        order=ord_1,
+        component=com_6,
+        price=7,
+        billable_flag=True,
+        size='R',
+        order_item_type='B component',
+        remark='Chat with him !')
+    oi_1.save()
+    oi_2 = Order_item(
+        order=ord_1,
+        component=com_12,
+        price=7,
+        billable_flag=True,
+        size='L',
+        order_item_type='B component',
+        remark='')
+    oi_2.save()
+    oi_3 = Order_item(
+        order=ord_2,
+        component=com_6,
+        price=7,
+        billable_flag=True,
+        size='L',
+        order_item_type='B component',
+        remark='')
+    oi_3.save()
+    oi_4 = Order_item(
+        order=ord_2,
+        component=com_6,
+        price=7,
+        billable_flag=True,
+        size='L',
+        order_item_type='B component',
+        remark='')
+    oi_4.save()
+    oi_5 = Order_item(
+        order=ord_2,
+        component=com_8,
+        price=7,
+        billable_flag=True,
+        size='L',
+        order_item_type='B component',
+        remark='')
+    oi_5.save()
+    oi_6 = Order_item(
+        order=ord_2,
+        component=com_8,
+        price=7,
+        billable_flag=True,
+        size='L',
+        order_item_type='B component',
+        remark='')
+    oi_6.save()
+    oi_7 = Order_item(
+        order=ord_1,
+        component=com_11,
+        price=7,
+        billable_flag=True,
+        size='L',
+        order_item_type='B component',
+        remark='')
+    oi_7.save()
+    oi_8 = Order_item(
+        order=ord_3,
+        component=com_6,
+        price=7,
+        billable_flag=True,
+        size='L',
+        order_item_type='B component',
+        remark='')
+    oi_8.save()
+    oi_9 = Order_item(
+        order=ord_3,
+        component=com_10,
+        price=7,
+        billable_flag=True,
+        size='L',
+        order_item_type='B component',
+        remark='')
+    oi_9.save()
+    oi_10 = Order_item(
+        order=ord_4,
+        component=com_6,
+        price=7,
+        billable_flag=True,
+        size='L',
+        order_item_type='B component',
+        remark='')
+    oi_10.save()
+    oi_11 = Order_item(
+        order=ord_4,
+        component=com_9,
+        price=7,
+        billable_flag=True,
+        size='L',
+        order_item_type='B component',
+        remark='')
+    oi_11.save()
+    #
+    print_all_cols(db.query(Order_item.sa))
+    print_rows(Order_item.objects)
+
+run()
+print("END dataload")

--- a/django/santropolFeast/delivery/apps.py
+++ b/django/santropolFeast/delivery/apps.py
@@ -1,5 +1,12 @@
 from django.apps import AppConfig
 
+# This allows to use SQLAlchemy for queries
+import aldjemy.core as ac
+from sqlalchemy.orm import sessionmaker
+engine = ac.get_engine()
+Session = sessionmaker(bind=engine)
+
 
 class DeliveryConfig(AppConfig):
     name = 'delivery'
+    Session = Session

--- a/django/santropolFeast/delivery/templates/kitchen_count.html
+++ b/django/santropolFeast/delivery/templates/kitchen_count.html
@@ -1,0 +1,35 @@
+{% extends "base_delivery.html" %}
+<!-- Load Internationalization utils-->
+{% load i18n %}
+
+{% block title %}{% trans 'Kitchen Count report' %} {% endblock %}
+
+{% block breadcrumb %}
+{% endblock breadcrumb %}
+
+{% block content %}
+    {{ kcrlist|linebreaks }}
+<table class="ui celled table">
+  <thead>
+    <th class="">{% trans 'Client' %}</th>
+    <th class="">{% trans 'Qty' %}</th>
+    <th class="">{% trans 'Size' %}</th>
+    <th class="">{% trans 'Section / Incompatibilities' %}</th>
+    <th class="">{% trans 'Other restrictions' %}</th>
+    <th class="">{% trans 'Preparation' %}</th>
+    <th class=""></th>
+  </thead>
+  <tbody>
+    {% for obj in lines %}
+      <tr>
+        <td><strong>{{obj.client}}</strong></td>
+        <td>{{obj.qty}}</td>
+        <td>{{obj.size}}</td>
+        <td>{{obj.incom}}</td>
+        <td>{{obj.restr}}</td>
+        <td>{{obj.prep}}</td>
+     </tr>
+        {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/django/santropolFeast/delivery/tests.py
+++ b/django/santropolFeast/delivery/tests.py
@@ -1,3 +1,14 @@
 from django.test import TestCase
 
-# Create your tests here.
+
+class KitchenCountReportTestCase(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        # This data set includes 'Ground porc' clashing ingredient
+        import dataload
+
+    def test_clashing_ingredient(self):
+        """An ingredient we know will clash must be in the page"""
+        response = self.client.get('/delivery/kitchen_count/')
+        self.assertTrue(b'Ground porc' in response.content)

--- a/django/santropolFeast/delivery/urls.py
+++ b/django/santropolFeast/delivery/urls.py
@@ -2,9 +2,11 @@ from django.conf.urls import url
 from django.utils.translation import ugettext_lazy as _
 
 from delivery.views import Orderlist, MealInformation, RoutesInformation
+from delivery.views import kcr_view
 
 urlpatterns = [
     url(_(r'^order/$'), Orderlist.as_view(), name='order'),
     url(_(r'^meal/$'), MealInformation.as_view(), name='meal'),
-    url(_(r'^route/$'), RoutesInformation.as_view(), name='route')
+    url(_(r'^route/$'), RoutesInformation.as_view(), name='route'),
+    url(_(r'^kitchen_count/$'), kcr_view, name='route')
 ]

--- a/django/santropolFeast/delivery/views.py
+++ b/django/santropolFeast/delivery/views.py
@@ -4,6 +4,21 @@ from django.utils.decorators import method_decorator
 from django.contrib.auth.decorators import login_required
 from delivery.models import Delivery
 
+from .apps import DeliveryConfig
+
+from sqlalchemy import func, or_, and_
+
+import datetime
+
+from meal.models import Component, Restricted_item, Ingredient
+from meal.models import Component_ingredient, Incompatibility
+from meal.models import Menu, Menu_component
+from member.models import Member, Client, Contact, Address, Note, Referencing
+from member.models import Route, Note, Option, Client_option, Restriction
+from member.models import Client_avoid_ingredient, Client_avoid_component
+from notification.models import Notification
+from order.models import Order, Order_item
+
 
 class Orderlist(generic.ListView):
     # Display all the order on a given day
@@ -21,3 +36,350 @@ class RoutesInformation(generic.ListView):
     # Display all the route information for a given day
     model = Delivery
     template_name = "routes.html"
+
+
+class Kitchen_item(object):
+    def __init__(self):
+        self.lastname = None
+        self.firstname = None
+        self.meal_qty = 0
+        self.meal_size = ''
+        self.incompatible_ingredients = []
+        self.incompatible_components = []
+        self.other_ingredients = []
+        self.other_components = []
+        self.restricted_items = []
+        self.preparation = []
+
+    def __str__(self):
+        return("[" +
+               'lastname=' + self.lastname + ', ' +
+               'firstname=' + self.firstname + ', ' +
+               'meal_qty=' + str(self.meal_qty) + ', ' +
+               'meal_size=' + str(self.meal_size) + ', ' +
+               'clash_ingre=' + repr(self.incompatible_ingredients) + ', ' +
+               'clash_compo=' + repr(self.incompatible_components) + ', ' +
+               'avoid_ingre=' + repr(self.other_ingredients) + ', ' +
+               'avoid_compo=' + repr(self.other_components) + ', ' +
+               'restr_items=' + repr(self.restricted_items) + ', ' +
+               'preparation=' + repr(self.preparation) + ']')
+
+
+class Line(object):
+    def __init__(self,
+                 client='', qty='', size='', incom='', restr='', prep=''):
+        self.client = client
+        self.qty = qty
+        self.size = size
+        self.incom = incom
+        self.restr = restr
+        self.prep = prep
+
+
+def print_rows(q, heading=""):
+    pass
+    # print("\n-----------------------------------------------------\n",
+    #       # q, "\n",
+    #       heading)
+    # for row in q.all():
+    #     print(row)
+
+
+def kcr_view(request):
+    db = DeliveryConfig.Session()
+
+    cli = Client.sa
+    mem = Member.sa
+    add = Address.sa
+    order = Order.sa
+    oi = Order_item.sa
+    comp = Component.sa
+    opt = Option.sa
+    co = Client_option.sa
+    rest = Restriction.sa
+    ri = Restricted_item.sa
+    ing = Ingredient.sa
+    inc = Incompatibility.sa
+    ci = Component_ingredient.sa
+    cai = Client_avoid_ingredient.sa
+    cac = Client_avoid_component.sa
+
+    qdainew = db.query(cli.id.label('cid'),
+                       mem.firstname, mem.lastname,
+                       order.id, order.delivery_date,
+                       ing.name.label('ingredient'), comp.name,
+                       oi.id, oi.order_id.label('oiorderid')).\
+        select_from(mem).\
+        join(cli, cli.member_id == mem.id).\
+        join(order, order.client_id == cli.id).\
+        join(cai, cai.client_id == cli.id).\
+        join(ing, ing.id == cai.ingredient_id).\
+        outerjoin(ci, ci.ingredient_id == ing.id).\
+        outerjoin(comp, comp.id == ci.component_id).\
+        outerjoin(oi, and_(oi.component_id == comp.id,
+                           oi.order_id == order.id)).\
+        filter(order.delivery_date == datetime.date(2016, 5, 21)).\
+        order_by(cli.id)
+    print_rows(qdainew,
+               "\n***** Day's avoid ingredients clashes NEW ****\nCLIENT_ID,"
+               "FIRSTNAME, LASTNAME, "
+               "ORDER_ID, ORDER_DELIV_DATE, "
+               "INGREDIENT_NAME, COMP_NAME, "
+               "ORDER_ITEM_ID, ORDER_ITEM_ORDER_ID")
+
+    qdacnew = db.query(cli.id.label('cid'),
+                       mem.firstname, mem.lastname,
+                       order.id, order.delivery_date,
+                       comp.name.label('component'),
+                       oi.id, oi.order_id.label('oiorderid')).\
+        select_from(mem).\
+        join(cli, cli.member_id == mem.id).\
+        join(order, order.client_id == cli.id).\
+        join(cac, cac.client_id == cli.id).\
+        join(comp, comp.id == cac.component_id).\
+        outerjoin(oi, and_(oi.component_id == comp.id,
+                           oi.order_id == order.id)).\
+        filter(order.delivery_date == datetime.date(2016, 5, 21)).\
+        order_by(cli.id)
+    print_rows(qdacnew,
+               "\n***** Day's avoid component clashes NEW ****\nCLIENT_ID,"
+               "FIRSTNAME, LASTNAME, "
+               "ORDER_ID, ORDER_DELIV_DATE, "
+               "COMP_NAME, "
+               "ORDER_ITEM_ID, ORDER_ITEM_ORDER_ID")
+
+    # No need to join with component, component_ingredient is enough
+    qdcrnew = db.query(cli.id.label('cid'),
+                       mem.firstname, mem.lastname,
+                       order.id, order.delivery_date,
+                       ri.name.label('restricted_item'),
+                       ing.name.label('ingredient'), comp.name,
+                       oi.id, oi.order_id.label('oiorderid')).\
+        select_from(mem).\
+        join(cli, cli.member_id == mem.id).\
+        join(order, order.client_id == cli.id).\
+        join(rest, rest.client_id == cli.id).\
+        join(ri, ri.id == rest.restricted_item_id).\
+        outerjoin(inc, inc.restricted_item_id == rest.restricted_item_id).\
+        outerjoin(ing, inc.ingredient_id == ing.id).\
+        outerjoin(ci, ci.ingredient_id == ing.id).\
+        outerjoin(comp, ci.component_id == comp.id).\
+        outerjoin(oi, and_(oi.component_id == comp.id,
+                           oi.order_id == order.id)).\
+        filter(order.delivery_date == datetime.date(2016, 5, 21)).\
+        order_by(cli.id)
+    print_rows(qdcrnew,
+               "\n***** Day's restrictions NEW ****\nCLIENT_ID,"
+               "FIRSTNAME, LASTNAME, "
+               "ORDER_ID, ORDER_DELIV_DATE, "
+               "RESTRICTED_ITEM, INGREDIENT_NAME, COMP_NAME, "
+               "ORDER_ITEM_ID, ORDER_ITEM_ORDER_ID")
+
+    qdpnnew = db.query(cli.id.label('cid'),
+                       mem.firstname, mem.lastname,
+                       opt.name.label('food_prep'),
+                       order.id, order.delivery_date).\
+        select_from(mem).\
+        join(cli, cli.member_id == mem.id).\
+        join(co, co.client_id == cli.id).\
+        join(opt, opt.id == co.option_id).\
+        join(order, order.client_id == cli.id).\
+        filter(order.delivery_date == datetime.date(2016, 5, 21),
+               opt.option_group == 'preparation').\
+        order_by(mem.lastname, mem.firstname)
+    print_rows(qdpnnew,
+               "\n***** Day's preparations NEW****\nCLIENT_ID,"
+               "FIRSTNAME, LASTNAME, "
+               "FOOD_PREP, "
+               "ORDER_ID, ORDER_DELIV_DATE")
+
+    # TODO add route filter, full address, order by postal code
+    qdlnnew = db.query(cli.id.label('cid'), mem.firstname, mem.lastname,
+                       add.street, add.postal_code,
+                       oi.total_quantity, oi.size,
+                       comp.component_group).\
+        select_from(mem).\
+        join(cli, cli.member_id == mem.id).\
+        join(add, add.id == mem.address_id).\
+        join(order, order.client_id == cli.id).\
+        join(oi, oi.order_id == order.id).\
+        join(comp, comp.id == oi.component_id).\
+        filter(order.delivery_date == datetime.date(2016, 5, 21)).\
+        order_by(add.postal_code, mem.lastname, mem.firstname)
+    print_rows(qdlnnew,
+               "\n***** Delivery List NEW ******\n CLIENT_ID,"
+               " FIRSTNAME, LASTNAME, "
+               "STREET, POSTAL_CODE, "
+               "OI_TOTAL_QUANTITY, OI_SIZE, "
+               "COMPONENT_GROUP, ")
+
+    # FIXME refactor Kitchen_item creation
+    kitchen_list = {}
+    kitchen_components = {}
+    for row in qdainew.all():
+        if not kitchen_list.get(row.cid):
+            # found new client
+            kitchen_list[row.cid] = Kitchen_item()
+            kitchen_list[row.cid].lastname = row.lastname
+            kitchen_list[row.cid].firstname = row.firstname
+        if row.oiorderid:
+            # found avoid ingredient clash
+            # FIXME should be a sorted set (or ordered dict ?)
+            kitchen_list[row.cid].incompatible_ingredients.append(
+                row.ingredient)
+        # FIXME we Know that it is not incommpatible
+        elif (row.ingredient not in
+              kitchen_list[row.cid].incompatible_ingredients):
+            # found new other avoid ingredient that does not clash today
+            # should be a set
+            kitchen_list[row.cid].other_ingredients.append(
+                row.ingredient)
+    for row in qdacnew.all():
+        if not kitchen_list.get(row.cid):
+            # found new client
+            kitchen_list[row.cid] = Kitchen_item()
+            kitchen_list[row.cid].lastname = row.lastname
+            kitchen_list[row.cid].firstname = row.firstname
+        if row.oiorderid:
+            # found avoid component clash
+            # FIXME should be a set
+            kitchen_list[row.cid].incompatible_components.append(
+                row.component)
+        # FIXME we Know that it is not incommpatible
+        elif (row.component not in
+              kitchen_list[row.cid].incompatible_components):
+            # found new other avoid component that does not clash today
+            # FIXME should be a set
+            kitchen_list[row.cid].other_components.append(
+                row.component)
+    for row in qdcrnew.all():
+        if not kitchen_list.get(row.cid):
+            # found new client
+            kitchen_list[row.cid] = Kitchen_item()
+            kitchen_list[row.cid].lastname = row.lastname
+            kitchen_list[row.cid].firstname = row.firstname
+        if row.oiorderid:
+            # found restriction clash
+            # FIXME here MUST be a sorted set
+            kitchen_list[row.cid].incompatible_ingredients.append(
+                row.ingredient)
+        elif (row.ingredient and row.ingredient not in
+              kitchen_list[row.cid].incompatible_ingredients):
+            # found new other restriction that does not clash today
+            # should be a set
+            kitchen_list[row.cid].other_ingredients.append(
+                row.ingredient)
+        kitchen_list[row.cid].restricted_items.append(
+            row.restricted_item)
+    for row in qdpnnew.all():
+        if not kitchen_list.get(row.cid):
+            # found new compatible client with food preparation
+            kitchen_list[row.cid] = Kitchen_item()
+            kitchen_list[row.cid].lastname = row.lastname
+            kitchen_list[row.cid].firstname = row.firstname
+        # should be a sorted set
+        kitchen_list[row.cid].preparation.append(row.food_prep)
+    for row in qdlnnew.all():
+        if not kitchen_list.get(row.cid):
+            # found new compatible client
+            #   (no avoids, no restrictions, no preparation)
+            kitchen_list[row.cid] = Kitchen_item()
+            kitchen_list[row.cid].lastname = row.lastname
+            kitchen_list[row.cid].firstname = row.firstname
+        if row.component_group == 'main dish':
+            # FIXME use total_quantity
+            kitchen_list[row.cid].meal_qty = kitchen_list[row.cid].meal_qty + 1
+            kitchen_list[row.cid].meal_size = row.size
+        kitchen_components.setdefault(row.component_group, 0)
+        kitchen_components[row.component_group] = \
+            kitchen_components[row.component_group] + 1
+
+    # sort requirements list in each item
+    for k, item in kitchen_list.items():
+        item.incompatible_ingredients.sort()
+        item.incompatible_components.sort()
+        item.other_ingredients.sort()
+        item.other_components.sort()
+        item.restricted_items.sort()
+        item.preparation.sort()
+
+    lines = []
+
+    lines.append(Line(incom='KCR Component Counts : ' +
+                      str(kitchen_components)))
+    lines.append(Line())
+
+    total = 0
+    lines.append(Line(incom='KCR list part 1 of 3 - COMPONENT CLASHING'))
+    subtotal = 0
+    for k, v in filter(lambda x: x[1].incompatible_components,
+                       kitchen_list.items()):
+        subtotal = subtotal + v.meal_qty
+        lines.append(Line(client=v.lastname + ', ' + v.firstname[0:2] + '.',
+                          qty=v.meal_qty, size=v.meal_size,
+                          incom='clash_compo=' +
+                          str(v.incompatible_components) +
+                          'clash_ingre=' + str(v.incompatible_ingredients),
+                          restr='avoid_compo=' + str(v.other_components) +
+                          'avoid_ingre=' + str(v.other_ingredients) +
+                          'restr_items=' + str(v.restricted_items),
+                          prep=str(v.preparation)))
+    else:
+        lines.append(Line(incom='Part 1 SUBTOTAL = ' + str(subtotal)))
+        total = total + subtotal
+    lines.append(Line())
+
+    lines.append(Line(incom='KCR list part 2 of 3 - INGREDIENTS CLASHING'))
+    subtotal = 0
+    combination = None
+    for k, v in sorted(
+            filter(lambda x: x[1].incompatible_ingredients,
+                   kitchen_list.items()),
+            key=lambda x: x[1].incompatible_ingredients):
+        if combination != v.incompatible_ingredients:
+            if combination:
+                lines.append(Line(incom='COMBINATION ' + str(combination) +
+                                  ' SUBTOTAL = ' + str(combtotal)))
+            combination = v.incompatible_ingredients
+            combtotal = 0
+        combtotal = combtotal + v.meal_qty
+        subtotal = subtotal + v.meal_qty
+        lines.append(Line(client=v.lastname + ', ' + v.firstname[0:2] + '.',
+                          qty=v.meal_qty, size=v.meal_size,
+                          incom='clash_compo=' +
+                          str(v.incompatible_components) +
+                          'clash_ingre=' + str(v.incompatible_ingredients),
+                          restr='avoid_compo=' + str(v.other_components) +
+                          'avoid_ingre=' + str(v.other_ingredients) +
+                          'restr_items=' + str(v.restricted_items),
+                          prep=str(v.preparation)))
+    else:
+        if combination:
+            lines.append(Line(incom='COMBINATION ' + str(combination) +
+                              ' SUBTOTAL = ' + str(combtotal)))
+            lines.append(Line(incom='Part 2 SUBTOTAL = ' + str(subtotal)))
+        total = total + subtotal
+    lines.append(Line())
+
+    lines.append(Line(incom='KCR list part 3 of 3 - NO CLASHES'))
+    subtotal = 0
+    for k, v in sorted(
+            filter(lambda x: not x[1].incompatible_ingredients,
+                   kitchen_list.items()),
+            key=lambda x: x[1].lastname + x[1].firstname):
+        subtotal = subtotal + v.meal_qty
+        lines.append(Line(client=v.lastname + ', ' + v.firstname[0:2] + '.',
+                          qty=v.meal_qty, size=v.meal_size,
+                          incom='clash_compo=' +
+                          str(v.incompatible_components) +
+                          'clash_ingre=' + str(v.incompatible_ingredients),
+                          restr='avoid_compo=' + str(v.other_components) +
+                          'avoid_ingre=' + str(v.other_ingredients) +
+                          'restr_items=' + str(v.restricted_items),
+                          prep=str(v.preparation)))
+    else:
+        lines.append(Line(incom='Part 3 SUBTOTAL = ' + str(subtotal)))
+        total = total + subtotal
+    lines.append(Line())
+    lines.append(Line(incom='Parts 1,2 and 3 TOTAL = ' + str(total)))
+    return render(request, 'kitchen_count.html', {'lines': lines})

--- a/django/santropolFeast/santropolFeast/settings.py
+++ b/django/santropolFeast/santropolFeast/settings.py
@@ -46,6 +46,7 @@ INSTALLED_APPS = [
     'delivery',
     'formtools',
     'django_filters',
+    'aldjemy',
 ]
 
 MIDDLEWARE_CLASSES = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ mysqlclient==1.3.7
 factory_boy==2.7.0
 django-formtools==1.0
 django-filter==0.13.0
+aldjemy==0.6.0


### PR DESCRIPTION
*Fixes # 234.*
*Fixes # 004 partly = proof of concept for Kitchen Count queries.*

### Changes proposed in this pull request:

*fix234 (first commit)*
* .travis.yml : coverage in one line for all apps. See solution (b) in explanation for issue https://github.com/savoirfairelinux/santropol-feast/issues/234

*fix004c (second commit)*
* delivery app : added view and test (but code refactoring and comments will follow later)
* delivery app : added template (just to show data, the layout has to be redone)
* test data for Kitchen Count Report : dataload.py and dataexec.py
* settings.py and requirements.txt : added aldjemy dependency
* .travis.yml :  added test for delivery

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### Deployment notes and migration

- [ ] Migration needed

* To see Kitchen Count Report, before runserver, run "python dataexec.py" to load data in database.
* endpoint is : /delivery/kitchen_count/

@savoirfairelinux/mll

