### PR TITLE
Add the possibility to attach an existing member to the client.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,5 @@ ENV/
 # Rope project settings
 .ropeproject
 
+# IDE project settings
+.idea

--- a/django/santropolFeast/member/forms.py
+++ b/django/santropolFeast/member/forms.py
@@ -243,8 +243,6 @@ class ClientPaymentInformation(MemberForm):
                 field_data = cleaned_data.get(field)
                 if not field_data:
                     self.add_error(field, msg)
-
-
         return cleaned_data
 
 

--- a/django/santropolFeast/member/forms.py
+++ b/django/santropolFeast/member/forms.py
@@ -1,7 +1,8 @@
 from django import forms
+from django.core.exceptions import ObjectDoesNotExist
 from django.utils.translation import ugettext_lazy as _
 from member.models import (
-    Client, RATE_TYPE, CONTACT_TYPE_CHOICES,
+    Member, Client, RATE_TYPE, CONTACT_TYPE_CHOICES,
     GENDER_CHOICES, PAYMENT_TYPE, DELIVERY_TYPE,
     DAYS_OF_WEEK
 )
@@ -10,67 +11,82 @@ from meal.models import Ingredient
 
 class ClientBasicInformation (forms.Form):
 
-    firstname = forms.CharField(max_length=100, label=_("First Name"),
-                                widget=forms.TextInput(
-                                    attrs={'placeholder': _('First name')}))
+    firstname = forms.CharField(
+        max_length=100,
+        label=_("First Name"),
+        widget=forms.TextInput(attrs={'placeholder': _('First name')})
+    )
 
-    lastname = forms.CharField(max_length=100, label=_("Last Name"),
-                               widget=forms.TextInput(
-        attrs={'placeholder': _('Last name')}))
+    lastname = forms.CharField(
+        max_length=100,
+        label=_("Last Name"),
+        widget=forms.TextInput(attrs={'placeholder': _('Last name')})
+    )
 
-    gender = forms.ChoiceField(choices=GENDER_CHOICES,
-                               widget=forms.Select(
-                                   attrs={'class': 'ui dropdown'}))
+    gender = forms.ChoiceField(
+        choices=GENDER_CHOICES,
+        widget=forms.Select(attrs={'class': 'ui dropdown'})
+    )
 
     language = forms.ChoiceField(
         choices=Client.LANGUAGES,
         label=_("Preferred language"),
-        widget=forms.Select(
-            attrs={
-                'class': 'ui dropdown'}))
+        widget=forms.Select(attrs={'class': 'ui dropdown'})
+    )
 
     birthdate = forms.DateField(label=_("Birthday"))
 
-    contact_type = forms.ChoiceField(choices=CONTACT_TYPE_CHOICES,
-                                     label=_("Contact Type"),
-                                     widget=forms.Select(
-                                         attrs={'class': 'ui dropdown'}))
+    contact_type = forms.ChoiceField(
+        choices=CONTACT_TYPE_CHOICES,
+        label=_("Contact Type"),
+        widget=forms.Select(attrs={'class': 'ui dropdown'})
+    )
 
     contact_value = forms.CharField(label=_("Contact information"))
 
-    alert = forms.CharField(label=_("Alert"),
-                            required=False,
-                            widget=forms.Textarea(
-        attrs={'rows': 2, 'placeholder': _('Your message here ...')}
-    ))
+    alert = forms.CharField(
+        label=_("Alert"),
+        required=False,
+        widget=forms.Textarea(attrs={
+            'rows': 2,
+            'placeholder': _('Your message here ...')
+        })
+    )
 
 
 class ClientAddressInformation(forms.Form):
 
-    number = forms.IntegerField(label=_("Street Number"),
-                                widget=forms.TextInput(
-                                    attrs={'placeholder': _('#')}))
-    number.required = False
+    number = forms.IntegerField(
+        label=_("Street Number"),
+        widget=forms.TextInput(attrs={'placeholder': _('#')}),
+        required=False
+    )
 
-    apartment = forms.IntegerField(label=_("Apt #"),
-                                   widget=forms.TextInput(
-        attrs={'placeholder': _('Apt #')}))
-    apartment.required = False
+    apartment = forms.IntegerField(
+        label=_("Apt #"),
+        widget=forms.TextInput(attrs={'placeholder': _('Apt #')}),
+        required=False
+    )
 
-    floor = forms.IntegerField(label=_("Floor"))
-    floor.required = False
+    floor = forms.IntegerField(label=_("Floor"), required=False)
 
-    street = forms.CharField(max_length=100, label=_("Street Name"),
-                             widget=forms.TextInput(
-        attrs={'placeholder': _('Street Address')}))
+    street = forms.CharField(
+        max_length=100,
+        label=_("Street Name"),
+        widget=forms.TextInput(attrs={'placeholder': _('Street Address')})
+    )
 
-    city = forms.CharField(max_length=50, label=_("City"),
-                           widget=forms.TextInput(
-        attrs={'placeholder': _('Montreal')}))
+    city = forms.CharField(
+        max_length=50,
+        label=_("City"),
+        widget=forms.TextInput(attrs={'placeholder': _('Montreal')})
+    )
 
-    postal_code = forms.CharField(max_length=6, label=_("Postal Code"),
-                                  widget=forms.TextInput(
-        attrs={'placeholder': _('H2R 2Y5')}))
+    postal_code = forms.CharField(
+        max_length=6,
+        label=_("Postal Code"),
+        widget=forms.TextInput(attrs={'placeholder': _('H2R 2Y5')})
+    )
 
 
 class ClientRestrictionsInformation(forms.Form):
@@ -85,18 +101,14 @@ class ClientRestrictionsInformation(forms.Form):
         label=_('Type'),
         choices=DELIVERY_TYPE,
         required=True,
-        widget=forms.Select(
-            attrs={'class': 'ui dropdown'}
-        )
+        widget=forms.Select(attrs={'class': 'ui dropdown'})
     )
 
     delivery_schedule = forms.MultipleChoiceField(
         label=_('Schedule'),
         initial='Select days of week',
         choices=DAYS_OF_WEEK,
-        widget=forms.SelectMultiple(
-            attrs={'class': 'ui dropdown'}
-        ),
+        widget=forms.SelectMultiple(attrs={'class': 'ui dropdown'}),
         required=False,
     )
 
@@ -107,61 +119,103 @@ class ClientRestrictionsInformation(forms.Form):
         label=_("Restrictions"),
         queryset=Ingredient.objects.all(),
         required=False,
-        widget=forms.SelectMultiple(
-            attrs={'class': 'ui dropdown search'})
+        widget=forms.SelectMultiple(attrs={'class': 'ui dropdown search'})
     )
 
 
-class ClientReferentInformation(forms.Form):
+class MemberForm(forms.Form):
 
-    firstname = forms.CharField(max_length=100, label=_("First Name"),
-                                widget=forms.TextInput(
-                                    attrs={'placeholder': _('First Name')}))
-    lastname = forms.CharField(max_length=100, label=_("Last Name"),
-                               widget=forms.TextInput(
-        attrs={'placeholder': _('Last Name')}))
+    member = forms.CharField(
+        label=_("Member"),
+        widget=forms.TextInput(attrs={
+            'placeholder': _('Member'),
+            'class': 'prompt existing--member'
+        }),
+        required=False
+    )
+
+    firstname = forms.CharField(
+        label=_("First Name"),
+        widget=forms.TextInput(attrs={
+            'placeholder': _('First Name'),
+            'class': 'firstname'
+        }),
+        required=False
+    )
+
+    lastname = forms.CharField(
+        label=_("Last Name"),
+        widget=forms.TextInput(attrs={
+            'placeholder': _('Last Name'),
+            'class': 'lastname'
+        }),
+        required=False
+    )
+
+    def clean(self):
+        cleaned_data = super(MemberForm, self).clean()
+        member = cleaned_data.get('member')
+        firstname = cleaned_data.get('firstname')
+        lastname = cleaned_data.get('lastname')
+
+        if not member and (not firstname or not lastname):
+            msg = _('This field is required unless you add a new member.')
+            self.add_error('member', msg)
+            msg = _(
+                'This field is required unless you chose an existing member.'
+            )
+            self.add_error('firstname', msg)
+            self.add_error('lastname', msg)
+
+        if member:
+            member_id = member.split(' ')[0].replace('[', '').replace(']', '')
+            try:
+                Member.objects.get(pk=member_id)
+            except ObjectDoesNotExist:
+                msg = _('Not a valid member, please chose an existing member.')
+                self.add_error('member', msg)
+        return cleaned_data
+
+
+class ClientReferentInformation(MemberForm):
 
     work_information = forms.CharField(
         max_length=200,
         label=_('Work information'),
-        widget=forms.TextInput(
-            attrs={
-                'placeholder': _('Hotel-Dieu, St-Anne Hospital, CLSC, ...')}))
+        widget=forms.TextInput(attrs={
+            'placeholder': _('Hotel-Dieu, St-Anne Hospital, ...')
+        })
+    )
 
-    referral_reason = forms.CharField(label=_("Referral Reason"),
-                                      widget=forms.Textarea(
-        attrs={'rows': 4}
-    ))
+    referral_reason = forms.CharField(
+        label=_("Referral Reason"),
+        widget=forms.Textarea(attrs={'rows': 4})
+    )
+
     date = forms.DateField(label=_("Referral Date"))
 
 
-class ClientPaymentInformation(forms.Form):
+class ClientPaymentInformation(MemberForm):
 
-    facturation = forms.ChoiceField(label=_("Billing Type"),
-                                    choices=RATE_TYPE,
-                                    widget=forms.Select(
-        attrs={'class': 'ui dropdown'})
+    facturation = forms.ChoiceField(
+        label=_("Billing Type"),
+        choices=RATE_TYPE,
+        widget=forms.Select(attrs={'class': 'ui dropdown'})
     )
 
-    billing_payment_type = forms.ChoiceField(label=_("Payment Type"),
-                                             choices=PAYMENT_TYPE,
-                                             widget=forms.Select(
-        attrs={'class': 'ui dropdown'})
+    billing_payment_type = forms.ChoiceField(
+        label=_("Payment Type"),
+        choices=PAYMENT_TYPE,
+        widget=forms.Select(attrs={'class': 'ui dropdown'})
     )
 
-    firstname = forms.CharField(label=_("First Name"), widget=forms.TextInput(
-        attrs={'placeholder': _('First Name')}))
+    number = forms.IntegerField(label=_("Street Number"), required=False)
 
-    lastname = forms.CharField(label=_("Last Name"), widget=forms.TextInput(
-        attrs={'placeholder': _('Last Name')}))
-
-    number = forms.IntegerField(label=_("Street Number"))
-    number.required = False
-
-    apartment = forms.IntegerField(label=_("Apt #"),
-                                   widget=forms.TextInput(
-        attrs={'placeholder': _('Apt #')}))
-    apartment.required = False
+    apartment = forms.IntegerField(
+        label=_("Apt #"),
+        widget=forms.TextInput(attrs={'placeholder': _('Apt #')}),
+        required=False
+    )
 
     floor = forms.IntegerField(label=_("Floor"))
     floor.required = False
@@ -172,18 +226,26 @@ class ClientPaymentInformation(forms.Form):
 
     postal_code = forms.CharField(label=_("Postal Code"))
 
+    def clean(self):
+        cleaned_data = super(ClientPaymentInformation, self).clean()
+        member = cleaned_data.get('member')
+        if member:
+            member_id = member.split(' ')[0].replace('[', '').replace(']', '')
+            member_obj = Member.objects.get(pk=member_id)
+            if not member_obj.address:
+                msg = _('This member has not a valid address, '
+                        'please add a valid address to this member, so it can '
+                        'be used for the billing.')
+                self.add_error('member', msg)
+        return cleaned_data
 
-class ClientEmergencyContactInformation(forms.Form):
 
-    firstname = forms.CharField(label=_("First Name"), widget=forms.TextInput(
-        attrs={'placeholder': _('First Name')}))
+class ClientEmergencyContactInformation(MemberForm):
 
-    lastname = forms.CharField(label=_("Last Name"), widget=forms.TextInput(
-        attrs={'placeholder': _('Last Name')}))
-
-    contact_type = forms.ChoiceField(label=_("Contact Type"),
-                                     choices=CONTACT_TYPE_CHOICES,
-                                     widget=forms.Select(
-                                         attrs={'class': 'ui dropdown'}))
+    contact_type = forms.ChoiceField(
+        label=_("Contact Type"),
+        choices=CONTACT_TYPE_CHOICES,
+        widget=forms.Select(attrs={'class': 'ui dropdown'})
+    )
 
     contact_value = forms.CharField(label=_("Contact"))

--- a/django/santropolFeast/member/forms.py
+++ b/django/santropolFeast/member/forms.py
@@ -217,14 +217,13 @@ class ClientPaymentInformation(MemberForm):
         required=False
     )
 
-    floor = forms.IntegerField(label=_("Floor"))
-    floor.required = False
+    floor = forms.IntegerField(label=_("Floor"), required=False)
 
-    street = forms.CharField(label=_("Street Name"))
+    street = forms.CharField(label=_("Street Name"), required=False)
 
-    city = forms.CharField(label=_("City Name"))
+    city = forms.CharField(label=_("City Name"), required=False)
 
-    postal_code = forms.CharField(label=_("Postal Code"))
+    postal_code = forms.CharField(label=_("Postal Code"), required=False)
 
     def clean(self):
         cleaned_data = super(ClientPaymentInformation, self).clean()
@@ -237,6 +236,15 @@ class ClientPaymentInformation(MemberForm):
                         'please add a valid address to this member, so it can '
                         'be used for the billing.')
                 self.add_error('member', msg)
+        else:
+            msg = _("This field is required")
+            fields = ['street', 'city', 'postal_code']
+            for field in fields:
+                field_data = cleaned_data.get(field)
+                if not field_data:
+                    self.add_error(field, msg)
+
+
         return cleaned_data
 
 

--- a/django/santropolFeast/member/templates/forms/form.html
+++ b/django/santropolFeast/member/templates/forms/form.html
@@ -9,140 +9,166 @@
 
 
 {% block extrahead %}
-    <link href="{% static 'css/calendar.min.css' %}" type="text/css" rel="stylesheet">
+  <link href="{% static 'css/calendar.min.css' %}" type="text/css" rel="stylesheet">
 {% endblock %}
 
 {% block title %}Create a new client{% endblock %}
 
 {% block message %}
 <div class="ui message">
-    <div class="header">
-    Welcome to the client creation form
-    </div>
-    <p>Fill out the form below to create a new client. No information will be saved until all the steps are completed.</p>
+  <div class="header">
+  Welcome to the client creation form
+  </div>
+  <p>Fill out the form below to create a new client. No information will be saved until all the steps are completed.</p>
 </div>
 {% endblock %}
 
 {% block content %}
 
 <div class="ui secondary pointing fluid menu">
-    <h2 class="ui header">New Client</h2>
+  <h2 class="ui header">New Client</h2>
 </div>
 
-    <div class="six wide column">
-        <div class="ui vertical steps">
+  <div class="six wide column">
+    <div class="ui vertical steps">
 
-            {% include 'forms/step.html' with step=1 icon='male' name=_('Personal') description=_('First name, last name, ...') %}
+      {% include 'forms/step.html' with step=1 icon='male' name=_('Personal') description=_('First name, last name, ...') %}
 
-            {% include 'forms/step.html' with step=2 icon='home' name=_('Address') description=_('Street number, city, ...') %}
+      {% include 'forms/step.html' with step=2 icon='home' name=_('Address') description=_('Street number, city, ...') %}
 
-            {% include 'forms/step.html' with step=3 icon='treatment' name=_('Referent') description=_('Referent contact information') %}
+      {% include 'forms/step.html' with step=3 icon='treatment' name=_('Referent') description=_('Referent contact information') %}
 
-            {% include 'forms/step.html' with step=4 icon='payment' name=_('Payment') description=_('Payment method, card, ...') %}
+      {% include 'forms/step.html' with step=4 icon='payment' name=_('Payment') description=_('Payment method, card, ...') %}
 
-            {% include 'forms/step.html' with step=5 icon='food' name=_('Allergies') description=_('Restrictions, allergies, ...') %}
+      {% include 'forms/step.html' with step=5 icon='food' name=_('Allergies') description=_('Restrictions, allergies, ...') %}
 
-            {% include 'forms/step.html' with step=6 icon='first aid' name=_('Emergency') description=_('Emergency contact information') %}
+      {% include 'forms/step.html' with step=6 icon='first aid' name=_('Emergency') description=_('Emergency contact information') %}
 
-        </div>
     </div>
+  </div>
 
     <div class="ten wide column form-steps">
 
-        <form action="" method="post" class="ui form error">{% csrf_token %}
-            {% if wizard.form.errors %}
-            <div class="ui error message">
-                <div class="header">{{ _('Required information missing')}}</div>
-                <p>{{ _('Please review the form to make sure that all required fields are filled.')}}</p>
-                {{ wizard.form.errors }}
+      <form action="" method="post" class="ui form error">{% csrf_token %}
+        {% if wizard.form.errors %}
+        <div class="ui error message">
+          <div class="header">{{ _('Required information missing')}}</div>
+          <p>{{ _('Please review the form to make sure that all required fields are filled.')}}</p>
+          {{ wizard.form.errors }}
+        </div>
+        {% endif %}
+        {{wizard.management_form}}
+
+        {% if wizard.form.forms %}
+
+          {{wizard.form.management_form}}
+
+          {% for form in wizard.form.forms}
+            <div class="ui small icon input">
+              sdfsfdsf
             </div>
-            {% endif %}
-            {{wizard.management_form}}
 
-            {% if wizard.form.forms %}
+        {% else %}
+          {% if wizard.steps.current == 'basic_information' %}
+            {% include 'forms/steps/basic_information.html' %}
+          {% elif wizard.steps.current == 'address_information' %}
+            {% include 'forms/steps/address_information.html' %}
+          {% elif wizard.steps.current == 'referent_information' %}
+            {% include 'forms/steps/referent_information.html' %}
+          {% elif wizard.steps.current == 'payment_information' %}
+            {% include 'forms/steps/payment_information.html' %}
+          {% elif wizard.steps.current == 'dietary_restriction' %}
+            {% include 'forms/steps/dietary_restriction.html' %}
+          {% elif wizard.steps.current == 'emergency_contact' %}
+            {% include 'forms/steps/emergency_contact.html' %}
+          {% else %}
 
-                {{wizard.form.management_form}}
+            {% for form in wizard.form %}
 
-                {% for form in wizard.form.forms}
-                    <div class="ui small icon input">
-                        sdfsfdsf
-                    </div>
+            <div class="field {% if form.errors %} error {% endif %}">
+              <label>{{ form.label }} ({{form.name}})</label>
+              {{ form }}
+            </div>
+          {% endfor %}
 
-            {% else %}
-                {% if wizard.steps.current == 'basic_information' %}
-                    {% include 'forms/steps/basic_information.html' %}
-                {% elif wizard.steps.current == 'address_information' %}
-                    {% include 'forms/steps/address_information.html' %}
-                {% elif wizard.steps.current == 'referent_information' %}
-                    {% include 'forms/steps/referent_information.html' %}
-                {% elif wizard.steps.current == 'payment_information' %}
-                    {% include 'forms/steps/payment_information.html' %}
-                {% elif wizard.steps.current == 'dietary_restriction' %}
-                    {% include 'forms/steps/dietary_restriction.html' %}
-                {% elif wizard.steps.current == 'emergency_contact' %}
-                    {% include 'forms/steps/emergency_contact.html' %}
-                {% else %}
+          {% endif %}
 
-                    {% for form in wizard.form %}
+        {% endif %}
 
-                    <div class="field {% if form.errors %} error {% endif %}">
-                        <label>{{ form.label }} ({{form.name}})</label>
-                        {{ form }}
-                    </div>
-                {% endfor %}
+        {% if wizard.steps.prev %}
+        <button class="ui left floated button" name="wizard_goto_step" type="submit" value="{{wizard.steps.prev}}">
+          {% trans "Back"%}
+        </button>
+        {% endif %}
 
-                {% endif %}
+        {% if wizard.steps.step1 == 6 %}
+          <input class="big ui right floated yellow button" type="submit" value="Save"/>
+        {% else %}
+          <button  class="big ui yellow right floated button" name="wizard_goto_step" type="submit">Next</button>
+        {% endif %}
 
-            {% endif %}
-
-            {% if wizard.steps.prev %}
-            <button class="ui left floated button" name="wizard_goto_step" type="submit" value="{{wizard.steps.prev}}">
-                {% trans "Back"%}
-            </button>
-            {% endif %}
-
-            {% if wizard.steps.step1 == 6 %}
-            <input class="big ui right floated yellow button" type="submit" value="Save"/>
-            {% else %}
-            <button  class="big ui yellow right floated button" name="wizard_goto_step" type="submit">Next</button>
-            {% endif %}
-
-        </form>
+      </form>
 </div>
 {% endblock %}
 
 {% block extrajs %}
-    <script src="{% static 'jquery/calendar.min.js' %}" type="application/javascript"></script>
-    <script type="text/javascript">
-        $(function() {
-            $('#wizard_form_birthdate').calendar({
-                type: 'date',
-                formatter: {
-                    date: function (date, settings) {
-                      if (!date) return '';
-                      var day = date.getDate();
-                      var month = date.getMonth() + 1;
-                      var year = date.getFullYear();
-                      if (month < 10) month = '0' + month;
-                      if (day < 10) day = '0' + day;
-                      return year + '-' + month + '-' + day;
-                    }
-                }
-            });
-            $('#wizard_form_date').calendar({
-                type: 'date',
-                formatter: {
-                    date: function (date, settings) {
-                      if (!date) return '';
-                      var day = date.getDate();
-                      var month = date.getMonth() + 1;
-                      var year = date.getFullYear();
-                      if (month < 10) month = '0' + month;
-                      if (day < 10) day = '0' + day;
-                      return year + '-' + month + '-' + day;
-                    }
-                }
-            });
+  <script src="{% static 'jquery/calendar.min.js' %}" type="application/javascript"></script>
+  <script type="text/javascript">
+    $(function() {
+      $('#wizard_form_birthdate').calendar({
+        type: 'date',
+        formatter: {
+          date: function (date, settings) {
+            if (!date) return '';
+            var day = date.getDate();
+            var month = date.getMonth() + 1;
+            var year = date.getFullYear();
+            if (month < 10) month = '0' + month;
+            if (day < 10) day = '0' + day;
+            return year + '-' + month + '-' + day;
+          }
+        }
+      });
+      $('#wizard_form_date').calendar({
+        type: 'date',
+        formatter: {
+          date: function (date, settings) {
+            if (!date) return '';
+            var day = date.getDate();
+            var month = date.getMonth() + 1;
+            var year = date.getFullYear();
+            if (month < 10) month = '0' + month;
+            if (day < 10) day = '0' + day;
+            return year + '-' + month + '-' + day;
+          }
+        }
+      });
+
+      $('.ui.button.add.member').on('click', function() {
+        $('.existing--member').val('').attr('disabled', 'disabled');
+        $(this).transition('scale');
+        $('.ui.add.form.member').transition('scale');
+      });
+      $('.ui.button.cancel.add.member').on('click', function() {
+        $('.ui.button.add.member').transition('scale');
+        $('.existing--member').removeAttr('disabled');
+      });
+      if( $('.firstname').val() !== '' || $('.lastname').val() !== ''
+          &&
+          $('.existing--member').val() === '' ) {
+        $('.ui.button.add.member').transition('scale');
+        $('.existing--member').attr('disabled', 'disabled');
+        $('.ui.add.form.member').transition('scale');
+      }
+      $('.ui.search')
+        .search({
+          apiSettings: {
+            cache : 'local',
+            url: '{% url 'member:search' %}?name={query}'
+          },
+          minCharacters : 3
         });
+    });
+
     </script>
 {% endblock %}

--- a/django/santropolFeast/member/templates/forms/steps/emergency_contact.html
+++ b/django/santropolFeast/member/templates/forms/steps/emergency_contact.html
@@ -1,25 +1,52 @@
-
 <h4 class="ui dividing header">{{ _('Emergency contact') }}</h4>
-<div class="field">
-    <label>{{ _('Name') }}</label>
-    <div class="two fields">
-      <div class="field {% if wizard.form.firstname.errors %} error {% endif %}">
-          {{wizard.form.firstname}}
-      </div>
-      <div class="field {% if wizard.form.lastname.errors %} error {% endif %}">
-          {{wizard.form.lastname}}
-      </div>
+
+<div class="ui center aligned basic segment">
+  <div class="ui fluid category search">
+    <div class="ui icon input">
+      {{wizard.form.member}}
+      <i class="search icon"></i>
     </div>
+    <div class="results"></div>
+  </div>
+  <div class="ui horizontal divider">
+    {{ _('Or') }}
+  </div>
+  <div class="ui teal labeled icon button add emergency contact member">
+    Create new emergency contact
+    <i class="add icon"></i>
+  </div>
+
+  <div class="ui form add emergency contact member transition hidden">
+    <div class="content">
+      <div class="ui icon button cancel add emergency contact member right floated">
+        <i class="close icon"></i>
+      </div>
+
+      <div class="field">
+        <label>{{ _('Name') }}</label>
+        <div class="two fields">
+          <div class="field {% if wizard.form.firstname.errors %} error {% endif %}">
+            {{wizard.form.firstname}}
+          </div>
+          <div class="field {% if wizard.form.lastname.errors %} error {% endif %}">
+            {{wizard.form.lastname}}
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </div>
 </div>
 
 <div class="field">
-    <label>{{ _('Contact information') }}</label>
-    <div class="two fields">
-      <div class="field">
-          {{wizard.form.contact_type}}
-      </div>
-      <div class="field {% if wizard.form.contact_value.errors %} error {% endif %}">
-          {{wizard.form.contact_value}}
-      </div>
+  <label>{{ _('Contact information') }}</label>
+  <div class="two fields">
+    <div class="field">
+      {{wizard.form.contact_type}}
     </div>
+    <div class="field {% if wizard.form.contact_value.errors %} error {% endif %}">
+      {{wizard.form.contact_value}}
+    </div>
+  </div>
 </div>
+

--- a/django/santropolFeast/member/templates/forms/steps/payment_information.html
+++ b/django/santropolFeast/member/templates/forms/steps/payment_information.html
@@ -1,15 +1,64 @@
 <h4 class="ui dividing header">{{ _('Billing information') }}</h4>
 
-<div class="field">
-    <label>{{ _('Name') }}</label>
-    <div class="two fields">
-      <div class="field {% if wizard.form.firstname.errors %} error {% endif %}">
-          {{wizard.form.firstname}}
-      </div>
-      <div class="field {% if wizard.form.lastname.errors %} error {% endif %}">
-          {{wizard.form.lastname}}
-      </div>
+<div class="ui center aligned basic segment">
+  <div class="ui fluid category search">
+    <div class="ui icon input">
+      {{wizard.form.member}}
+      <i class="search icon"></i>
     </div>
+    <div class="results"></div>
+  </div>
+  <div class="ui horizontal divider">
+    {{ _('Or') }}
+  </div>
+  <div class="ui teal labeled icon button add payment member">
+    Create new payment member
+    <i class="add icon"></i>
+  </div>
+
+  <div class="ui form add payment member transition hidden">
+    <div class="content">
+      <div class="ui icon button cancel add payment member right floated">
+        <i class="close icon"></i>
+      </div>
+
+      <div class="field">
+        <label>{{ _('Name') }}</label>
+        <div class="two fields">
+          <div class="field {% if wizard.form.firstname.errors %} error {% endif %}">
+              {{wizard.form.firstname}}
+          </div>
+          <div class="field {% if wizard.form.lastname.errors %} error {% endif %}">
+              {{wizard.form.lastname}}
+          </div>
+        </div>
+      </div>
+
+      <div class="field">
+        <label>{{ _('Street') }}</label>
+        <div class="fields">
+          <div class="twelve wide field {% if wizard.form.street.errors %} error {% endif %}">
+            {{ wizard.form.street}}
+          </div>
+          <div class="four wide field">
+            {{ wizard.form.apartment }}
+          </div>
+        </div>
+      </div>
+
+      <div class="equal width fields">
+        <div class="field {% if wizard.form.city.errors %} error {% endif %}">
+          <label>{{ wizard.form.city.label }}</label>
+          {{ wizard.form.city }}
+        </div>
+        <div class="field {% if wizard.form.postal_code.errors %} error {% endif %}">
+            <label>{{ wizard.form.postal_code.label }}</label>
+            {{ wizard.form.postal_code }}
+        </div>
+      </div>
+
+    </div>
+  </div>
 </div>
 
 <div class="field">
@@ -20,27 +69,4 @@
 <div class="field">
     <label>{{ wizard.form.facturation.label }}</label>
     {{ wizard.form.facturation }}
-</div>
-
-<div class="field">
-    <label>{{ _('Street') }}</label>
-    <div class="fields">
-      <div class="twelve wide field {% if wizard.form.street.errors %} error {% endif %}">
-        {{ wizard.form.street}}
-      </div>
-      <div class="four wide field">
-        {{ wizard.form.apartment }}
-      </div>
-    </div>
-</div>
-
-<div class="equal width fields">
-    <div class="field {% if wizard.form.city.errors %} error {% endif %}">
-      <label>{{ wizard.form.city.label }}</label>
-      {{ wizard.form.city }}
-    </div>
-    <div class="field {% if wizard.form.postal_code.errors %} error {% endif %}">
-        <label>{{ wizard.form.postal_code.label }}</label>
-        {{ wizard.form.postal_code }}
-    </div>
 </div>

--- a/django/santropolFeast/member/templates/forms/steps/referent_information.html
+++ b/django/santropolFeast/member/templates/forms/steps/referent_information.html
@@ -7,17 +7,43 @@
 
 <h4 class="ui dividing header">{{ _('Identity') }}</h4>
 
-<div class="field">
-    <label>{{ _('Name') }}</label>
-    <div class="two fields">
-      <div class="field {% if wizard.form.firstname.errors %} error {% endif %}">
-          {{wizard.form.firstname}}
+
+<div class="ui center aligned basic segment">
+  <div class="ui fluid category search">
+    <div class="ui icon input">
+      {{wizard.form.member}}
+      <i class="search icon"></i>
+    </div>
+    <div class="results"></div>
+  </div>
+  <div class="ui horizontal divider">
+    {{ _('Or') }}
+  </div>
+  <div class="ui teal labeled icon button add referent member">
+    Create new referent member
+    <i class="add icon"></i>
+  </div>
+
+  <div class="ui form add referent member transition hidden">
+    <div class="content">
+      <div class="ui icon button cancel add referent member right floated">
+        <i class="close icon"></i>
       </div>
-      <div class="field {% if wizard.form.lastname.errors %} error {% endif %}">
-          {{wizard.form.lastname}}
+      <div class="field">
+        <label>{{ _('Name') }}</label>
+        <div class="two fields">
+          <div class="field {% if wizard.form.firstname.errors %} error {% endif %}">
+              {{wizard.form.firstname}}
+          </div>
+          <div class="field {% if wizard.form.lastname.errors %} error {% endif %}">
+              {{wizard.form.lastname}}
+          </div>
+        </div>
       </div>
     </div>
+  </div>
 </div>
+
 
 <div class="field {% if wizard.form.work_information.errors %} error {% endif %}">
     <label>{{ wizard.form.work_information.label }}</label>

--- a/django/santropolFeast/member/tests.py
+++ b/django/santropolFeast/member/tests.py
@@ -502,8 +502,8 @@ class FormTestCase(TestCase):
         member = Member.objects.get(firstname="User")
 
         # test_member_name:
-        self.assertTrue(member.firstname, "User")
-        self.assertTrue(member.lastname, "Testing")
+        self.assertEqual(member.firstname, "User")
+        self.assertEqual(member.lastname, "Testing")
 
         # test_home_phone_member:
         self.assertTrue(member.get_home_phone().value.startswith('555'))
@@ -511,76 +511,85 @@ class FormTestCase(TestCase):
         client = Client.objects.get(member=member)
 
         # test_client_alert:
-        self.assertTrue(client.alert, "Testing alert message")
+        self.assertEqual(client.alert, "Testing alert message")
 
         # test_client_languages:
-        self.assertTrue(client.language, "fr")
+        self.assertEqual(client.language, "fr")
 
         # test_client_birthdate:
-        self.assertTrue(client.birthdate, "1990-12-12")
+        self.assertEqual(client.birthdate, date(1990, 12, 12))
 
         # test_client_gender:
-        self.assertTrue(client.gender, "M")
+        self.assertEqual(client.gender, "M")
 
         # test_client_contact_type:
-        self.assertTrue(member.member_contact, "Home phone")
+        self.assertEqual(member.member_contact.first().type, "Home phone")
 
         # test_client_address:
-        self.assertTrue(member.address.street, "555 rue clark")
-        self.assertTrue(member.address.postal_code, "H3C2C2")
-        self.assertTrue(member.address.apartment, "222")
-        self.assertTrue(member.address.city, "montreal")
+        self.assertEqual(member.address.street, "555 rue clark")
+        self.assertEqual(member.address.postal_code, "H3C2C2")
+        self.assertEqual(member.address.apartment, "222")
+        self.assertEqual(member.address.city, "montreal")
 
         # test client delivery type
         self.assertEqual(client.delivery_type, 'O')
 
         # test_referent_name:
-        self.assertTrue(
+        self.assertEqual(
             client.client_referent.first().referent.firstname,
             "Referent"
         )
-        self.assertTrue(
+        self.assertEqual(
             client.client_referent.first().referent.lastname,
             "Testing"
         )
 
         # test_referent_work_information:
-        self.assertTrue(
+        self.assertEqual(
             client.client_referent.first().work_information,
             "CLSC"
         )
 
         # test_referral_date(self):
-        self.assertTrue(client.client_referent.first().date, "2012-12-12")
+        self.assertEqual(
+            client.client_referent.first().date,
+            date(2012, 12, 12)
+        )
 
         # test_referral_reason:
-        self.assertTrue(
+        self.assertEqual(
             client.client_referent.first().referral_reason,
             "Testing referral reason"
         )
 
         # test_billing_name:
-        self.assertTrue(client.billing_member.firstname, "Testing")
-        self.assertTrue(client.billing_member.lastname, "Billing")
+        self.assertEqual(client.billing_member.firstname, "Billing")
+        self.assertEqual(client.billing_member.lastname, "Testing")
 
         #  test_billing_type:
-        self.assertTrue(client.billing_payment_type, "check")
+        self.assertEqual(client.billing_payment_type, "check")
 
         #  test_billing_address:
-        self.assertTrue(client.billing_member.address.city, "Montreal")
-        self.assertTrue(client.billing_member.address.street, "111 rue clark")
-        self.assertTrue(client.billing_member.address.postal_code, "H2C3G4")
+        self.assertEqual(client.billing_member.address.city, "Montreal")
+        self.assertEqual(client.billing_member.address.street, "111 rue clark")
+        self.assertEqual(client.billing_member.address.postal_code, "H2C3G4")
 
         #  test_billing_rate_type:
-        self.assertTrue(client.rate_type, 'default')
+        self.assertEqual(client.rate_type, 'default')
 
         #  test_emergency_contact_name:
-        self.assertTrue(client.emergency_contact.firstname, "Emergency")
-        self.assertTrue(client.emergency_contact.lastname, "User")
+        self.assertEqual(client.emergency_contact.firstname, "Emergency")
+        self.assertEqual(client.emergency_contact.lastname, "User")
+
+        #  test_emergency_contact_type:
+        self.assertEqual(
+            client.emergency_contact.member_contact.first().type,
+            "Home phone"
+        )
 
         #  test_emergency_contact_value:
-        self.assertTrue(
-            client.emergency_contact.get_home_phone,
+        self.assertEqual(
+            client.emergency_contact.member_contact.first().value,
             "555-444-5555"
         )
 

--- a/django/santropolFeast/member/tests.py
+++ b/django/santropolFeast/member/tests.py
@@ -334,6 +334,19 @@ class FormTestCase(TestCase):
             email='admin@example.com',
             password='test1234'
         )
+        address = Address.objects.create(
+            number=123, street='De Bullion',
+            city='Montreal', postal_code='H3C4G5'
+        )
+        Member.objects.create(
+            firstname='First',
+            lastname='Member',
+            address=address
+        )
+        Member.objects.create(
+            firstname='Second',
+            lastname='Member'
+        )
 
     def test_acces_to_form(self):
         """Test if the form is accesible from its url"""
@@ -422,7 +435,7 @@ class FormTestCase(TestCase):
     def test_form_save_data(self):
 
         basic_information_data = {
-            "client_wizard-current_step": "basic_info",
+            "client_wizard-current_step": "basic_information",
             "basic_information-firstname": "User",
             "basic_information-lastname": "Testing",
             "basic_information-language": "fr",
@@ -593,5 +606,414 @@ class FormTestCase(TestCase):
             "555-444-5555"
         )
 
+    def test_form_validate_data(self):
+        """Test all the step of the form with and without wrong data"""
+        self._test_basic_information_with_errors()
+        self._test_basic_information_without_errors()
+        self._test_address_information_with_errors()
+        self._test_address_information_without_errors()
+        self._test_referent_information_with_errors()
+        self._test_referent_information_without_errors()
+        self._test_payment_information_with_errors()
+        self._test_payment_information_without_errors()
+        self._test_step_dietary_restriction_with_errors()
+        self._test_step_dietary_restriction_without_errors()
+        self._test_step_emergency_contact_with_errors()
+        self._test_step_emergency_contact_without_errors()
+
+    def _test_basic_information_with_errors(self):
+        # Data for the basic_information step with errors.
+        basic_information_data_with_error = {
+            "client_wizard-current_step": "basic_information",
+            "basic_information-firstname": "User",
+            "basic_information-lastname": "",
+            "basic_information-language": "fr",
+            "basic_information-gender": "M",
+            "basic_information-birthdate": "",
+            "basic_information-contact_type": "Home phone",
+            "basic_information-contact_value": "",
+            "basic_information-alert": "",
+            "wizard_goto_step": ""
+        }
+
+        # Send the data to the form.
+        basic_information_error_response = self.client.post(
+            reverse_lazy('member:member_step', kwargs={'step': "basic_information"}),
+            basic_information_data_with_error,
+            follow=True
+        )
+
+        # Validate that the response is the same form with the errors messages.
+        self.assertTrue(
+            b'Please review the form to make sure that all required fields are filled.'
+            in basic_information_error_response.content
+        )
+        self.assertTrue(b'lastname' in basic_information_error_response.content)
+        self.assertTrue(b'birthdate' in basic_information_error_response.content)
+        self.assertTrue(b'contact_value' in basic_information_error_response.content)
+        self.assertTrue(b'This field is required' in basic_information_error_response.content)
+
+    def _test_basic_information_without_errors(self):
+        # Data for the basic_information step without errors.
+        basic_information_data = {
+            "client_wizard-current_step": "basic_info",
+            "basic_information-firstname": "User",
+            "basic_information-lastname": "Testing",
+            "basic_information-language": "fr",
+            "basic_information-gender": "M",
+            "basic_information-birthdate": "1990-12-12",
+            "basic_information-contact_type": "Home phone",
+            "basic_information-contact_value": "555-555-5555",
+            "basic_information-alert": "Testing alert message",
+            "wizard_goto_step": ""
+        }
+
+        # Send the data to the form.
+        basic_information_response = self.client.post(
+            reverse_lazy('member:member_step', kwargs={'step': "basic_information"}),
+            basic_information_data,
+            follow=True
+        )
+
+        # Validate that the response is the next step of the form with no errors messages.
+        self.assertTrue(
+            b'Please review the form to make sure that all required fields are filled.'
+            not in basic_information_response.content
+        )
+        self.assertTrue(b'gender' not in basic_information_response.content)
+        self.assertTrue(b'contact_value' not in basic_information_response.content)
+        self.assertTrue(b'This field is required' not in basic_information_response.content)
+        # HTML from the next step
+        self.assertTrue(b'street' in basic_information_response.content)
+
+    def _test_address_information_with_errors(self):
+        # Data for the address_information step with errors.
+        address_information_data_with_error = {
+            "client_wizard-current_step": "address_information",
+            "address_information-street": "",
+            "address_information-apartment": "",
+            "address_information-city": "",
+            "address_information-postal_code": "",
+            "wizard_goto_step": "",
+        }
+
+        # Send the data to the form.
+        address_information_response_error = self.client.post(
+            reverse_lazy('member:member_step', kwargs={'step': "address_information"}),
+            address_information_data_with_error,
+            follow=True
+        )
+
+        # Validate that the response is the same form with the errors messages.
+        self.assertTrue(
+            b'Please review the form to make sure that all required fields are filled.'
+            in address_information_response_error.content
+        )
+        self.assertTrue(b'street' in address_information_response_error.content)
+        self.assertTrue(b'apartment' in address_information_response_error.content)
+        self.assertTrue(b'city' in address_information_response_error.content)
+        self.assertTrue(b'This field is required' in address_information_response_error.content)
+
+    def _test_address_information_without_errors(self):
+        # Data for the address_information step without errors.
+        address_information_data = {
+            "client_wizard-current_step": "address_information",
+            "address_information-street": "555 rue clark",
+            "address_information-apartment": "222",
+            "address_information-city": "montreal",
+            "address_information-postal_code": "H3C2C2",
+            "wizard_goto_step": "",
+        }
+
+        # Send the data to the form.
+        address_information_response = self.client.post(
+            reverse_lazy('member:member_step', kwargs={'step': "address_information"}),
+            address_information_data,
+            follow=True
+        )
+
+        # Validate that the response is the next step of the form with no errors messages.
+        self.assertTrue(
+            b'Please review the form to make sure that all required fields are filled.'
+            not in address_information_response.content
+        )
+        self.assertTrue(b'street' not in address_information_response.content)
+        self.assertTrue(b'apartment' not in address_information_response.content)
+        self.assertTrue(b'This field is required' not in address_information_response.content)
+        # HTML from the next step
+        self.assertTrue(b'work_information' in address_information_response.content)
+
+    def _test_referent_information_with_errors(self):
+        # Data for the address_information step with errors.
+        referent_information_data_with_error = {
+            "client_wizard-current_step": "referent_information",
+            "id_referent_information-member" : "",
+            "referent_information-firstname": "",
+            "referent_information-lastname": "",
+            "referent_information-work_information": "",
+            "referent_information-date": "",
+            "referent_information-referral_reason": "",
+            "wizard_goto_step": "",
+        }
+
+        # Send the data to the form.
+        referent_information_response_error = self.client.post(
+            reverse_lazy('member:member_step', kwargs={'step': "referent_information"}),
+            referent_information_data_with_error,
+            follow=True
+        )
+
+        # Validate that the response is the same form with the errors messages.
+        self.assertTrue(
+            b'Please review the form to make sure that all required fields are filled.'
+            in referent_information_response_error.content
+        )
+        self.assertTrue(b'member' in referent_information_response_error.content)
+        self.assertTrue(b'work_information' in referent_information_response_error.content)
+        self.assertTrue(b'This field is required' in referent_information_response_error.content)
+
+    def _test_referent_information_without_errors(self):
+        referent_information_data = {
+            "client_wizard-current_step": "referent_information",
+            "referent_information-member": "[1] First Member",
+            "referent_information-firstname": "",
+            "referent_information-lastname": "",
+            "referent_information-work_information": "CLSC",
+            "referent_information-date": "2012-12-12",
+            "referent_information-referral_reason": "Testing referral reason",
+            "wizard_goto_step": "",
+        }
+
+        # Send the data to the form.
+        referent_information_response = self.client.post(
+            reverse_lazy('member:member_step', kwargs={'step': "referent_information"}),
+            referent_information_data,
+            follow=True
+        )
+
+        # Validate that the response is the next step of the form with no errors messages.
+        self.assertTrue(
+            b'Please review the form to make sure that all required fields are filled.'
+            not in referent_information_response.content
+        )
+        self.assertTrue(b'work_information' not in referent_information_response.content)
+        self.assertTrue(b'This field is required' not in referent_information_response.content)
+        # HTML from the next step
+        self.assertTrue(b'billing_payment_type' in referent_information_response.content)
+
+    def _test_payment_information_with_errors(self):
+        # Data for the address_information step with errors.
+        payment_information_data_with_error = {
+            "client_wizard-current_step": "payment_information",
+            "payment_information-member": "[2] Second Member",
+            "payment_information-firstname": "",
+            "payment_information-lastname": "",
+            "payment_information-billing_payment_type": "check",
+            "payment_information-facturation": "default",
+            "payment_information-street": "",
+            "payment_information-apartement": "",
+            "payment_information-city": "",
+            "payment_information-postal_code": "",
+            "wizard_goto_step": "",
+        }
+
+        # Send the data to the form.
+        payment_information_response_error = self.client.post(
+            reverse_lazy('member:member_step', kwargs={'step': "payment_information"}),
+            payment_information_data_with_error,
+            follow=True
+        )
+
+        # Validate that the response is the same form with the errors messages.
+        self.assertTrue(
+            b'Please review the form to make sure that all required fields are filled.'
+            in payment_information_response_error.content
+        )
+        self.assertTrue(b'billing_payment_type' in payment_information_response_error.content)
+        self.assertTrue(b'facturation' in payment_information_response_error.content)
+        self.assertTrue(
+            b'member has not a valid address'
+            in payment_information_response_error.content
+        )
+
+    def _test_payment_information_without_errors(self):
+        # Data for the address_information step without errors.
+        payment_information_data = {
+            "client_wizard-current_step": "payment_information",
+            "payment_information-member": "[1] First Member",
+            "payment_information-firstname": "",
+            "payment_information-lastname": "",
+            "payment_information-billing_payment_type": "check",
+            "payment_information-facturation": "default",
+            "payment_information-street": "",
+            "payment_information-apartement": "",
+            "payment_information-city": "",
+            "payment_information-postal_code": "",
+            "wizard_goto_step": "",
+        }
+
+        # Send the data to the form.
+        payment_information_response = self.client.post(
+            reverse_lazy('member:member_step', kwargs={'step': "payment_information"}),
+            payment_information_data,
+            follow=True
+        )
+
+        # Validate that the response is the next step of the form with no errors messages.
+        self.assertTrue(
+            b'Please review the form to make sure that all required fields are filled.'
+            not in payment_information_response.content
+        )
+        self.assertTrue(b'billing_payment_type' not in payment_information_response.content)
+        self.assertTrue(b'facturation' not in payment_information_response.content)
+        self.assertTrue(
+            b'member has not a valid address'
+            not in payment_information_response.content
+        )
+        # HTML from the next step
+        self.assertTrue(b'status' in payment_information_response.content)
+
+    def _test_step_dietary_restriction_with_errors(self):
+        # Data for the address_information step with errors.
+        restriction_information_data_with_error = {
+            "client_wizard-current_step": "dietary_restriction",
+            "dietary_restriction-status": "",
+            "dietary_restriction-delivery_type": "",
+            "dietary_restriction-delivery_schedule": "",
+            "dietary_restriction-meal_default": "",
+            "wizard_goto_step": ""
+        }
+
+        # Send the data to the form.
+        dietary_restriction_response_error = self.client.post(
+            reverse_lazy('member:member_step', kwargs={'step': "dietary_restriction"}),
+            restriction_information_data_with_error,
+            follow=True
+        )
+
+        # Validate that the response is the same form with the errors messages.
+        self.assertTrue(
+            b'Please review the form to make sure that all required fields are filled.'
+            in dietary_restriction_response_error.content
+        )
+        self.assertTrue(b'status' in dietary_restriction_response_error.content)
+        self.assertTrue(b'delivery_type' in dietary_restriction_response_error.content)
+        self.assertTrue(b'delivery_schedule' in dietary_restriction_response_error.content)
+
+    def _test_step_dietary_restriction_without_errors(self):
+        # Data for the address_information step without errors.
+        restriction_information_data = {
+            "client_wizard-current_step": "dietary_restriction",
+            "dietary_restriction-status": "on",
+            "dietary_restriction-delivery_type": "O",
+            "dietary_restriction-delivery_schedule": "mon",
+            "dietary_restriction-meal_default": "1",
+            "wizard_goto_step": ""
+        }
+
+        # Send the data to the form.
+        dietary_restriction_data = self.client.post(
+            reverse_lazy('member:member_step', kwargs={'step': "dietary_restriction"}),
+            restriction_information_data,
+            follow=True
+        )
+
+        # Validate that the response is the next step of the form with no errors messages.
+        self.assertTrue(
+            b'Please review the form to make sure that all required fields are filled.'
+            not in dietary_restriction_data.content
+        )
+        self.assertTrue(b'status' not in dietary_restriction_data.content)
+        self.assertTrue(b'delivery_type' not in dietary_restriction_data.content)
+        self.assertTrue(b'delivery_schedule' not in dietary_restriction_data.content)
+        # HTML from the next step
+        self.assertTrue(b'contact_type' in dietary_restriction_data.content)
+
+    def _test_step_emergency_contact_with_errors(self):
+        # Data for the address_information step with errors.
+        emergency_contact_data_with_error = {
+            "client_wizard-current_step": "emergency_contact",
+            "emergency_contact-firstname": "",
+            "emergency_contact-lastname": "",
+            "emergency_contact-contact_type": "Home phone",
+            "emergency_contact-contact_value": ""
+        }
+
+        # Send the data to the form.
+        emergency_contact_response_error = self.client.post(
+            reverse_lazy('member:member_step', kwargs={'step': "emergency_contact"}),
+            emergency_contact_data_with_error,
+            follow=True
+        )
+
+        # Validate that the response is the next step of the form with no errors messages.
+        self.assertTrue(
+            b'Please review the form to make sure that all required fields are filled.'
+            in emergency_contact_response_error.content
+        )
+        self.assertTrue(b'contact_type' in emergency_contact_response_error.content)
+        self.assertTrue(b'contact_value' in emergency_contact_response_error.content)
+
+    def _test_step_emergency_contact_without_errors(self):
+        # Data for the address_information step without errors.
+        emergency_contact_data = {
+            "client_wizard-current_step": "emergency_contact",
+            "emergency_contact-firstname": "Emergency",
+            "emergency_contact-lastname": "User",
+            "emergency_contact-contact_type": "Home phone",
+            "emergency_contact-contact_value": "555-444-5555"
+        }
+
+        # Send the data to the form.
+        emergency_contact_response = self.client.post(
+            reverse_lazy('member:member_step', kwargs={'step': "emergency_contact"}),
+            emergency_contact_data,
+            follow=True
+        )
+
+        # Validate that the response is the next step of the form with no errors messages.
+        self.assertTrue(
+            b'Please review the form to make sure that all required fields are filled.'
+            not in emergency_contact_response.content
+        )
+        self.assertTrue(b'status' not in emergency_contact_response.content)
+        self.assertTrue(b'delivery_type' not in emergency_contact_response.content)
+        self.assertTrue(b'delivery_schedule' not in emergency_contact_response.content)
+
+
     def tear_down(self):
         self.client.logout()
+
+
+class MemberSearchTestCase(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        member = Member.objects.create(
+            firstname='Katrina', lastname='Heide')
+        Contact.objects.create(
+            type='Home phone', value='514-456-7890', member=member)
+
+    def test_search_member_by_firstname(self):
+        """
+        A member must be find if the search use
+        at least 3 characters of his first name
+        """
+        result = self.client.get(
+            reverse_lazy('member:search') + '?name=Heid',
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest',
+            follow=True
+        )
+        self.assertTrue(b'Katrina Heide' in result.content)
+
+    def test_search_member_by_lastname(self):
+        """
+        A member must be find if the search use
+        at least 3 characters of his last name
+        """
+        result = self.client.get(
+            reverse_lazy('member:search') + '?name=Katri',
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest',
+            follow=True
+        )
+        self.assertTrue(b'Katrina Heide' in result.content)

--- a/django/santropolFeast/member/tests.py
+++ b/django/santropolFeast/member/tests.py
@@ -637,21 +637,21 @@ class FormTestCase(TestCase):
         }
 
         # Send the data to the form.
-        basic_information_error_response = self.client.post(
-            reverse_lazy('member:member_step', kwargs={'step': "basic_information"}),
+        error_response = self.client.post(
+            reverse_lazy(
+                'member:member_step',
+                kwargs={'step': "basic_information"}
+            ),
             basic_information_data_with_error,
             follow=True
         )
 
-        # Validate that the response is the same form with the errors messages.
-        self.assertTrue(
-            b'Please review the form to make sure that all required fields are filled.'
-            in basic_information_error_response.content
-        )
-        self.assertTrue(b'lastname' in basic_information_error_response.content)
-        self.assertTrue(b'birthdate' in basic_information_error_response.content)
-        self.assertTrue(b'contact_value' in basic_information_error_response.content)
-        self.assertTrue(b'This field is required' in basic_information_error_response.content)
+        # The response is the same form with the errors messages.
+        self.assertTrue(b'Required information' in error_response.content)
+        self.assertTrue(b'lastname' in error_response.content)
+        self.assertTrue(b'birthdate' in error_response.content)
+        self.assertTrue(b'contact_value' in error_response.content)
+        self.assertTrue(b'This field is required' in error_response.content)
 
     def _test_basic_information_without_errors(self):
         # Data for the basic_information step without errors.
@@ -669,22 +669,22 @@ class FormTestCase(TestCase):
         }
 
         # Send the data to the form.
-        basic_information_response = self.client.post(
-            reverse_lazy('member:member_step', kwargs={'step': "basic_information"}),
+        response = self.client.post(
+            reverse_lazy(
+                'member:member_step',
+                kwargs={'step': "basic_information"}
+            ),
             basic_information_data,
             follow=True
         )
 
-        # Validate that the response is the next step of the form with no errors messages.
-        self.assertTrue(
-            b'Please review the form to make sure that all required fields are filled.'
-            not in basic_information_response.content
-        )
-        self.assertTrue(b'gender' not in basic_information_response.content)
-        self.assertTrue(b'contact_value' not in basic_information_response.content)
-        self.assertTrue(b'This field is required' not in basic_information_response.content)
+        # The response is the next step of the form with no errors messages.
+        self.assertTrue(b'Required information' not in response.content)
+        self.assertTrue(b'gender' not in response.content)
+        self.assertTrue(b'contact_value' not in response.content)
+        self.assertTrue(b'This field is required' not in response.content)
         # HTML from the next step
-        self.assertTrue(b'street' in basic_information_response.content)
+        self.assertTrue(b'street' in response.content)
 
     def _test_address_information_with_errors(self):
         # Data for the address_information step with errors.
@@ -698,21 +698,21 @@ class FormTestCase(TestCase):
         }
 
         # Send the data to the form.
-        address_information_response_error = self.client.post(
-            reverse_lazy('member:member_step', kwargs={'step': "address_information"}),
+        response_error = self.client.post(
+            reverse_lazy(
+                'member:member_step',
+                kwargs={'step': "address_information"}
+            ),
             address_information_data_with_error,
             follow=True
         )
 
-        # Validate that the response is the same form with the errors messages.
-        self.assertTrue(
-            b'Please review the form to make sure that all required fields are filled.'
-            in address_information_response_error.content
-        )
-        self.assertTrue(b'street' in address_information_response_error.content)
-        self.assertTrue(b'apartment' in address_information_response_error.content)
-        self.assertTrue(b'city' in address_information_response_error.content)
-        self.assertTrue(b'This field is required' in address_information_response_error.content)
+        # The response is the same form with the errors messages.
+        self.assertTrue(b'Required information' in response_error.content)
+        self.assertTrue(b'street' in response_error.content)
+        self.assertTrue(b'apartment' in response_error.content)
+        self.assertTrue(b'city' in response_error.content)
+        self.assertTrue(b'This field is required' in response_error.content)
 
     def _test_address_information_without_errors(self):
         # Data for the address_information step without errors.
@@ -726,28 +726,27 @@ class FormTestCase(TestCase):
         }
 
         # Send the data to the form.
-        address_information_response = self.client.post(
-            reverse_lazy('member:member_step', kwargs={'step': "address_information"}),
+        response = self.client.post(
+            reverse_lazy(
+                'member:member_step',
+                kwargs={'step': "address_information"}),
             address_information_data,
             follow=True
         )
 
-        # Validate that the response is the next step of the form with no errors messages.
-        self.assertTrue(
-            b'Please review the form to make sure that all required fields are filled.'
-            not in address_information_response.content
-        )
-        self.assertTrue(b'street' not in address_information_response.content)
-        self.assertTrue(b'apartment' not in address_information_response.content)
-        self.assertTrue(b'This field is required' not in address_information_response.content)
+        # The response is the next step of the form with no errors messages.
+        self.assertTrue(b'Required information' not in response.content)
+        self.assertTrue(b'street' not in response.content)
+        self.assertTrue(b'apartment' not in response.content)
+        self.assertTrue(b'This field is required' not in response.content)
         # HTML from the next step
-        self.assertTrue(b'work_information' in address_information_response.content)
+        self.assertTrue(b'work_information' in response.content)
 
     def _test_referent_information_with_errors(self):
         # Data for the address_information step with errors.
         referent_information_data_with_error = {
             "client_wizard-current_step": "referent_information",
-            "id_referent_information-member" : "",
+            "referent_information-member": "",
             "referent_information-firstname": "",
             "referent_information-lastname": "",
             "referent_information-work_information": "",
@@ -757,20 +756,20 @@ class FormTestCase(TestCase):
         }
 
         # Send the data to the form.
-        referent_information_response_error = self.client.post(
-            reverse_lazy('member:member_step', kwargs={'step': "referent_information"}),
+        response_error = self.client.post(
+            reverse_lazy(
+                'member:member_step',
+                kwargs={'step': "referent_information"}
+            ),
             referent_information_data_with_error,
             follow=True
         )
 
         # Validate that the response is the same form with the errors messages.
-        self.assertTrue(
-            b'Please review the form to make sure that all required fields are filled.'
-            in referent_information_response_error.content
-        )
-        self.assertTrue(b'member' in referent_information_response_error.content)
-        self.assertTrue(b'work_information' in referent_information_response_error.content)
-        self.assertTrue(b'This field is required' in referent_information_response_error.content)
+        self.assertTrue(b'Required information' in response_error.content)
+        self.assertTrue(b'member' in response_error.content)
+        self.assertTrue(b'work_information' in response_error.content)
+        self.assertTrue(b'This field is required' in response_error.content)
 
     def _test_referent_information_without_errors(self):
         referent_information_data = {
@@ -785,21 +784,21 @@ class FormTestCase(TestCase):
         }
 
         # Send the data to the form.
-        referent_information_response = self.client.post(
-            reverse_lazy('member:member_step', kwargs={'step': "referent_information"}),
+        response = self.client.post(
+            reverse_lazy(
+                'member:member_step',
+                kwargs={'step': "referent_information"}
+            ),
             referent_information_data,
             follow=True
         )
 
-        # Validate that the response is the next step of the form with no errors messages.
-        self.assertTrue(
-            b'Please review the form to make sure that all required fields are filled.'
-            not in referent_information_response.content
-        )
-        self.assertTrue(b'work_information' not in referent_information_response.content)
-        self.assertTrue(b'This field is required' not in referent_information_response.content)
+        # The response is the next step of the form with no errors messages.
+        self.assertTrue(b'Required information' not in response.content)
+        self.assertTrue(b'work_information' not in response.content)
+        self.assertTrue(b'This field is required' not in response.content)
         # HTML from the next step
-        self.assertTrue(b'billing_payment_type' in referent_information_response.content)
+        self.assertTrue(b'billing_payment_type' in response.content)
 
     def _test_payment_information_with_errors(self):
         # Data for the address_information step with errors.
@@ -818,22 +817,22 @@ class FormTestCase(TestCase):
         }
 
         # Send the data to the form.
-        payment_information_response_error = self.client.post(
-            reverse_lazy('member:member_step', kwargs={'step': "payment_information"}),
+        response_error = self.client.post(
+            reverse_lazy(
+                'member:member_step',
+                kwargs={'step': "payment_information"}
+            ),
             payment_information_data_with_error,
             follow=True
         )
 
         # Validate that the response is the same form with the errors messages.
-        self.assertTrue(
-            b'Please review the form to make sure that all required fields are filled.'
-            in payment_information_response_error.content
-        )
-        self.assertTrue(b'billing_payment_type' in payment_information_response_error.content)
-        self.assertTrue(b'facturation' in payment_information_response_error.content)
+        self.assertTrue(b'Required information' in response_error.content)
+        self.assertTrue(b'billing_payment_type' in response_error.content)
+        self.assertTrue(b'facturation' in response_error.content)
         self.assertTrue(
             b'member has not a valid address'
-            in payment_information_response_error.content
+            in response_error.content
         )
 
     def _test_payment_information_without_errors(self):
@@ -853,25 +852,24 @@ class FormTestCase(TestCase):
         }
 
         # Send the data to the form.
-        payment_information_response = self.client.post(
-            reverse_lazy('member:member_step', kwargs={'step': "payment_information"}),
+        response = self.client.post(
+            reverse_lazy(
+                'member:member_step',
+                kwargs={'step': "payment_information"}
+            ),
             payment_information_data,
             follow=True
         )
 
-        # Validate that the response is the next step of the form with no errors messages.
+        # The response is the next step of the form with no errors messages.
+        self.assertTrue(b'Required information' not in response.content)
+        self.assertTrue(b'billing_payment_type' not in response.content)
+        self.assertTrue(b'facturation' not in response.content)
         self.assertTrue(
-            b'Please review the form to make sure that all required fields are filled.'
-            not in payment_information_response.content
-        )
-        self.assertTrue(b'billing_payment_type' not in payment_information_response.content)
-        self.assertTrue(b'facturation' not in payment_information_response.content)
-        self.assertTrue(
-            b'member has not a valid address'
-            not in payment_information_response.content
+            b'member has not a valid address' not in response.content
         )
         # HTML from the next step
-        self.assertTrue(b'status' in payment_information_response.content)
+        self.assertTrue(b'status' in response.content)
 
     def _test_step_dietary_restriction_with_errors(self):
         # Data for the address_information step with errors.
@@ -885,20 +883,20 @@ class FormTestCase(TestCase):
         }
 
         # Send the data to the form.
-        dietary_restriction_response_error = self.client.post(
-            reverse_lazy('member:member_step', kwargs={'step': "dietary_restriction"}),
+        response_error = self.client.post(
+            reverse_lazy(
+                'member:member_step',
+                kwargs={'step': "dietary_restriction"}
+            ),
             restriction_information_data_with_error,
             follow=True
         )
 
         # Validate that the response is the same form with the errors messages.
-        self.assertTrue(
-            b'Please review the form to make sure that all required fields are filled.'
-            in dietary_restriction_response_error.content
-        )
-        self.assertTrue(b'status' in dietary_restriction_response_error.content)
-        self.assertTrue(b'delivery_type' in dietary_restriction_response_error.content)
-        self.assertTrue(b'delivery_schedule' in dietary_restriction_response_error.content)
+        self.assertTrue(b'Required information' in response_error.content)
+        self.assertTrue(b'status' in response_error.content)
+        self.assertTrue(b'delivery_type' in response_error.content)
+        self.assertTrue(b'delivery_schedule' in response_error.content)
 
     def _test_step_dietary_restriction_without_errors(self):
         # Data for the address_information step without errors.
@@ -912,22 +910,22 @@ class FormTestCase(TestCase):
         }
 
         # Send the data to the form.
-        dietary_restriction_data = self.client.post(
-            reverse_lazy('member:member_step', kwargs={'step': "dietary_restriction"}),
+        response = self.client.post(
+            reverse_lazy(
+                'member:member_step',
+                kwargs={'step': "dietary_restriction"}
+            ),
             restriction_information_data,
             follow=True
         )
 
-        # Validate that the response is the next step of the form with no errors messages.
-        self.assertTrue(
-            b'Please review the form to make sure that all required fields are filled.'
-            not in dietary_restriction_data.content
-        )
-        self.assertTrue(b'status' not in dietary_restriction_data.content)
-        self.assertTrue(b'delivery_type' not in dietary_restriction_data.content)
-        self.assertTrue(b'delivery_schedule' not in dietary_restriction_data.content)
+        # The response is the next step of the form with no errors messages.
+        self.assertTrue(b'Required information' not in response.content)
+        self.assertTrue(b'status' not in response.content)
+        self.assertTrue(b'delivery_type' not in response.content)
+        self.assertTrue(b'delivery_schedule' not in response.content)
         # HTML from the next step
-        self.assertTrue(b'contact_type' in dietary_restriction_data.content)
+        self.assertTrue(b'contact_type' in response.content)
 
     def _test_step_emergency_contact_with_errors(self):
         # Data for the address_information step with errors.
@@ -940,19 +938,19 @@ class FormTestCase(TestCase):
         }
 
         # Send the data to the form.
-        emergency_contact_response_error = self.client.post(
-            reverse_lazy('member:member_step', kwargs={'step': "emergency_contact"}),
+        response_error = self.client.post(
+            reverse_lazy(
+                'member:member_step',
+                kwargs={'step': "emergency_contact"}
+            ),
             emergency_contact_data_with_error,
             follow=True
         )
 
-        # Validate that the response is the next step of the form with no errors messages.
-        self.assertTrue(
-            b'Please review the form to make sure that all required fields are filled.'
-            in emergency_contact_response_error.content
-        )
-        self.assertTrue(b'contact_type' in emergency_contact_response_error.content)
-        self.assertTrue(b'contact_value' in emergency_contact_response_error.content)
+        # The response is the next step of the form with no errors messages.
+        self.assertTrue(b'Required information' in response_error.content)
+        self.assertTrue(b'contact_type' in response_error.content)
+        self.assertTrue(b'contact_value' in response_error.content)
 
     def _test_step_emergency_contact_without_errors(self):
         # Data for the address_information step without errors.
@@ -965,21 +963,20 @@ class FormTestCase(TestCase):
         }
 
         # Send the data to the form.
-        emergency_contact_response = self.client.post(
-            reverse_lazy('member:member_step', kwargs={'step': "emergency_contact"}),
+        response = self.client.post(
+            reverse_lazy(
+                'member:member_step',
+                kwargs={'step': "emergency_contact"}
+            ),
             emergency_contact_data,
             follow=True
         )
 
-        # Validate that the response is the next step of the form with no errors messages.
-        self.assertTrue(
-            b'Please review the form to make sure that all required fields are filled.'
-            not in emergency_contact_response.content
-        )
-        self.assertTrue(b'status' not in emergency_contact_response.content)
-        self.assertTrue(b'delivery_type' not in emergency_contact_response.content)
-        self.assertTrue(b'delivery_schedule' not in emergency_contact_response.content)
-
+        # The response is the next step of the form with no errors messages.
+        self.assertTrue(b'Required information' not in response.content)
+        self.assertTrue(b'status' not in response.content)
+        self.assertTrue(b'delivery_type' not in response.content)
+        self.assertTrue(b'delivery_schedule' not in response.content)
 
     def tear_down(self):
         self.client.logout()

--- a/django/santropolFeast/member/urls.py
+++ b/django/santropolFeast/member/urls.py
@@ -3,7 +3,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from member.views import (
     ClientWizard, NoteList, mark_as_read,
-    show_information, ClientList
+    show_information, ClientList, SearchMembers
 )
 
 from member.forms import (
@@ -29,6 +29,7 @@ urlpatterns = [
     url(r'^create/(?P<step>.+)/$', member_wizard,
         name='member_step'),
     url(r'^list/$', ClientList.as_view(), name='list'),
+    url(r'^search/$', SearchMembers.as_view(), name='search'),
     url(_(r'^notes/$'), NoteList.as_view(), name='notes'),
     url(_(r'^note/read/(?P<id>[0-9]{1})/$'),
         mark_as_read, name='read'),

--- a/django/santropolFeast/member/views.py
+++ b/django/santropolFeast/member/views.py
@@ -2,10 +2,11 @@
 
 from django.views import generic
 from django.utils.decorators import method_decorator
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseRedirect, JsonResponse
 from django.core.urlresolvers import reverse_lazy
 from django.shortcuts import get_object_or_404
 from django.contrib.auth.decorators import login_required
+from django.db.models import Q
 from member.models import Client, Member, Address, Contact, Note
 from member.models import Referencing, ClientFilter, Note, ClientFilter
 from formtools.wizard.views import NamedUrlSessionWizardView
@@ -26,13 +27,15 @@ class ClientWizard(NamedUrlSessionWizardView):
     def save(self):
         """Save the client"""
 
-        basic_information = self.form_dict['basic_information']
-        address_information = self.form_dict['address_information']
-        referent_information = self.form_dict['referent_information']
-        payment_information = self.form_dict['payment_information']
-        dietary_restriction = self.form_dict['dietary_restriction']
-        emergency_contact = self.form_dict['emergency_contact']
+        address = self.save_address()
+        member = self.save_member(address)
+        billing_member = self.save_billing_member(member)
+        emergency = self.save_emergency_contact(billing_member)
+        client = self.save_client(member, billing_member, emergency)
+        self.save_referent_information(client, billing_member, emergency)
 
+    def save_address(self):
+        address_information = self.form_dict['address_information']
         address = Address.objects.create(
             number=address_information.cleaned_data.get('number'),
             street=address_information.cleaned_data.get('street'),
@@ -44,6 +47,10 @@ class ClientWizard(NamedUrlSessionWizardView):
             postal_code=address_information.cleaned_data.get('postal_code'),
         )
         address.save()
+        return address
+
+    def save_member(self, address):
+        basic_information = self.form_dict['basic_information']
 
         member = Member.objects.create(
             firstname=basic_information.cleaned_data.get('firstname'),
@@ -52,8 +59,25 @@ class ClientWizard(NamedUrlSessionWizardView):
         )
         member.save()
 
-        # Should be created only if third-party billing member
-        if True:
+        contact = Contact.objects.create(
+            type=basic_information.cleaned_data.get('contact_type'),
+            value=basic_information.cleaned_data.get("contact_value"),
+            member=member,
+        )
+        contact.save()
+
+        return member
+
+    def save_billing_member(self, member):
+        payment_information = self.form_dict['payment_information']
+        e_b_member = payment_information.cleaned_data.get('member')
+        if self.billing_member_is_member():
+            billing_member = member
+        elif e_b_member:
+            e_b_member_id = e_b_member.split(' ')[0].\
+                replace('[', '').replace(']', '')
+            billing_member = Member.objects.get(pk=e_b_member_id)
+        else:
             billing_address = Address.objects.create(
                 number=payment_information.cleaned_data.get('number'),
                 street=payment_information.cleaned_data.get('street'),
@@ -69,24 +93,28 @@ class ClientWizard(NamedUrlSessionWizardView):
             billing_member = Member.objects.create(
                 firstname=payment_information.cleaned_data.get('firstname'),
                 lastname=payment_information.cleaned_data.get('lastname'),
-                address=address,
+                address=billing_address,
             )
             billing_member.save()
+
+        return billing_member
+
+    def save_emergency_contact(self, billing_member):
+        emergency_contact = self.form_dict['emergency_contact']
+        e_emergency_member = emergency_contact.cleaned_data.get('member')
+        if self.payment_is_emergency_contact():
+            emergency = billing_member
+        elif e_emergency_member:
+            e_emergency_member_id = e_emergency_member.split(' ')[0]\
+                .replace('[', '')\
+                .replace(']', '')
+            emergency = Member.objects.get(pk=e_emergency_member_id)
         else:
-            billing_member = member
-
-        contact = Contact.objects.create(
-            type=basic_information.cleaned_data.get('contact_type'),
-            value=basic_information.cleaned_data.get("contact_value"),
-            member=member,
-        )
-        contact.save()
-
-        emergency = Member.objects.create(
-            firstname=emergency_contact.cleaned_data.get("firstname"),
-            lastname=emergency_contact.cleaned_data.get('lastname'),
-        )
-        emergency.save()
+            emergency = Member.objects.create(
+                firstname=emergency_contact.cleaned_data.get("firstname"),
+                lastname=emergency_contact.cleaned_data.get('lastname'),
+            )
+            emergency.save()
 
         client_emergency_contact = Contact.objects.create(
             type=emergency_contact.cleaned_data.get("contact_type"),
@@ -97,7 +125,13 @@ class ClientWizard(NamedUrlSessionWizardView):
             member=emergency,
         )
         client_emergency_contact.save()
+        return emergency
 
+    def save_client(self, member, billing_member, emergency):
+        dietary_restriction = self.form_dict['dietary_restriction']
+        payment_information = self.form_dict['payment_information']
+        basic_information = self.form_dict['basic_information']
+        # Client SAVE
         client = Client.objects.create(
             rate_type=payment_information.cleaned_data.get("facturation"),
             billing_payment_type=payment_information.cleaned_data.get(
@@ -116,16 +150,26 @@ class ClientWizard(NamedUrlSessionWizardView):
             client.status = 'A'
 
         client.save()
+        return client
 
-        referent = Member.objects.create(
-            firstname=referent_information.cleaned_data.get(
-                "firstname"
-            ),
-            lastname=referent_information.cleaned_data.get(
-                "lastname"
-            ),
-        )
-        referent.save()
+    def save_referent_information(self, client, billing_member, emergency):
+        referent_information = self.form_dict['referent_information']
+        e_referent = referent_information.cleaned_data.get('member')
+        if self.referent_is_billing_member():
+            referent = billing_member
+        elif self.referent_is_emergency_contact():
+            referent = emergency
+        elif e_referent:
+            e_referent_id = e_referent.split(' ')[0]\
+                .replace('[', '')\
+                .replace(']', '')
+            referent = Member.objects.get(pk=e_referent_id)
+        else:
+            referent = Member.objects.create(
+                firstname=referent_information.cleaned_data.get("firstname"),
+                lastname=referent_information.cleaned_data.get("lastname"),
+            )
+            referent.save()
 
         referencing = Referencing.objects.create(
             referent=referent,
@@ -141,6 +185,63 @@ class ClientWizard(NamedUrlSessionWizardView):
             ),
         )
         referencing.save()
+        return referencing
+
+    def billing_member_is_member(self):
+        basic_information = self.form_dict['basic_information']
+        payment_information = self.form_dict['payment_information']
+
+        b_firstname = basic_information.cleaned_data.get('firstname')
+        b_lastname = basic_information.cleaned_data.get('lastname')
+
+        p_firstname = payment_information.cleaned_data.get('firstname')
+        p_lastname = payment_information.cleaned_data.get('lastname')
+
+        if b_firstname == p_firstname and b_lastname == p_lastname:
+            return True
+        return False
+
+    def payment_is_emergency_contact(self):
+        emergency_contact = self.form_dict['emergency_contact']
+        payment_information = self.form_dict['payment_information']
+
+        e_firstname = emergency_contact.cleaned_data.get('firstname')
+        e_lastname = emergency_contact.cleaned_data.get('lastname')
+
+        p_firstname = payment_information.cleaned_data.get('firstname')
+        p_lastname = payment_information.cleaned_data.get('lastname')
+
+        if e_firstname == p_firstname and e_lastname == p_lastname:
+            return True
+        return False
+
+    def referent_is_emergency_contact(self):
+        emergency_contact = self.form_dict['emergency_contact']
+        referent_information = self.form_dict['referent_information']
+
+        e_firstname = emergency_contact.cleaned_data.get('firstname')
+        e_lastname = emergency_contact.cleaned_data.get('lastname')
+
+        r_firstname = referent_information.cleaned_data.get("firstname")
+        r_lastname = referent_information.cleaned_data.get("lastname")
+
+        if e_firstname == r_firstname and e_lastname == r_lastname:
+            return True
+        return False
+
+    def referent_is_billing_member(self):
+        referent_information = self.form_dict['referent_information']
+        payment_information = self.form_dict['payment_information']
+
+        r_firstname = referent_information.cleaned_data.get("firstname")
+        r_lastname = referent_information.cleaned_data.get("lastname")
+
+        p_firstname = payment_information.cleaned_data.get('firstname')
+        p_lastname = payment_information.cleaned_data.get('lastname')
+
+        if r_firstname == p_firstname and r_lastname == p_lastname:
+            return True
+        return False
 
 
 class ClientList(generic.ListView):
@@ -478,3 +579,31 @@ def mark_as_read(request, id):
     note = get_object_or_404(Note, pk=id)
     note.mark_as_read()
     return HttpResponseRedirect(reverse_lazy("member:notes"))
+
+
+class SearchMembers(generic.View):
+
+    def get(self, request):
+        if request.is_ajax():
+            q = self.request.GET.get('name', '')
+            name_contains = Q()
+            firstname_contains = Q(
+                firstname__icontains=q
+            )
+            lastname_contains = Q(
+                lastname__icontains=q
+            )
+            name_contains |= firstname_contains | lastname_contains
+            members = Member.objects.filter(name_contains)[:20]
+            results = []
+            for m in members:
+                name = '[' + str(m.id) + '] ' + m.firstname + ' ' + m.lastname
+                results.append({'title': name})
+            data = {
+                'success': True,
+                'results': results
+            }
+        else:
+            data = {'success': False}
+
+        return JsonResponse(data)


### PR DESCRIPTION
*Fixes issue #223 .*

### Changes proposed in this pull request:

* Update the tests because in a previous commit I had used assertTrue instead of assterEqual
* Add a route and a view for making ajax request in order to
find the existing members.
* Update the templates to add the new input to search existing
members and the JavaScript code needed.
* Update the view ClientWizard to add the existing member to the
client when needed, also split the long save method into several
logic methods that are reused in the save method.

 * Important change : Right now I have decided that if the
client information and the payment information is the same
(First Name and Last Name) only one member is created in the
DataBase, because if not we end with lots of members that basically
have the same information. Is the same with the payment information
and the referent information, maybe the person referencing the
client is the same that will pay for it, and right now we create
two differents members in the DataBase. I'm not sure how this should
be handled and I will be happy to change this into the right way.


### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### Deployment notes and migration

- [ ] Migration needed
