### PR TITLE
Change the client view to display the meal default

### DIFF
--- a/django/santropolFeast/member/templates/client/view/view.html
+++ b/django/santropolFeast/member/templates/client/view/view.html
@@ -110,6 +110,18 @@
                 </div>
                 {% endfor %}
             </div>
+            <h3 class="ui header">
+              {% trans "Meal Default" %}
+              <a href="{% url 'admin:member_client_change' client.id %}">
+                <i class="write grey icon"></i>
+              </a>
+            </h3>
+            {% for default in meal_default %}
+
+            <div>
+              {{default}}
+            </div>
+            {% endfor %}
         </div>
 
         <div class="ui bottom attached tab segment" data-tab="third">
@@ -192,7 +204,6 @@
             {% endfor %}
         </div>
       </div>
-    </div>
 </div>
 
 <script type="text/javascript">

--- a/django/santropolFeast/member/views.py
+++ b/django/santropolFeast/member/views.py
@@ -47,6 +47,9 @@ class ClientWizard(NamedUrlSessionWizardView):
                 'size_{}'.format(days)
                 )
 
+            if json['size_{}'.format(days)] is "":
+                json['size_{}'.format(days)] = None
+
             for meal in meals:
                 json['{}_{}_quantity'.format(meal, days)] \
                     = dictonary.cleaned_data.get(
@@ -363,9 +366,23 @@ class ClientAllergiesView(generic.DetailView):
 def show_information(request, id):
     client = get_object_or_404(Client, pk=id)
     notes = list(Note.objects.all())
+    meal_default = parse_json(client.meal_default_week)
 
     return render(request, 'client/view/view.html',
-                  {'client': client, 'notes': notes})
+                  {
+                      'client': client, 'notes': notes,
+                      'meal_default': meal_default
+                      })
+
+
+def parse_json(meals):
+    meal_default = []
+
+    for meal in meals:
+        if meals[meal] is not None:
+            meal_default.append(meal + ": " + str(meals[meal]))
+
+    return meal_default
 
 
 class ClientPreferencesView(generic.DetailView):


### PR DESCRIPTION
*Fixes #244 

### Changes proposed in this pull request:

* add a tab to show the meal default under the preference tab

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### Deployment notes and migration

- [ ] Migration needed


@savoirfairelinux/mll

