### PR TITLE
Add requirement for the pdf export

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ django-formtools==1.0
 django-filter==0.13.0
 aldjemy==0.6.0
 django-annoying==0.9.0
+reportlab==3.3.0


### PR DESCRIPTION
### Changes proposed in this pull request:

* Add requirement to export pdf (https://docs.djangoproject.com/en/1.9/howto/outputting-pdf/)

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

@savoirfairelinux/mll

