### PR TITLE
Add new commands to generate orders using factory-boy

### DIFF
--- a/django/santropolFeast/dataload.py
+++ b/django/santropolFeast/dataload.py
@@ -181,31 +181,31 @@ def insert_all():
     # -----------------------------------------------------------------------------
     com_1 = Component(
         name='Coq au vin',
-        component_group='main dish')
+        component_group='main_dish')
     com_1.save()
     com_2 = Component(
         name='Meat pie',
-        component_group='main dish')
+        component_group='main_dish')
     com_2.save()
     com_3 = Component(
         name='Vegetable fried rice',
-        component_group='main dish')
+        component_group='main_dish')
     com_3.save()
     com_4 = Component(
         name='Sausage cassoulet',
-        component_group='main dish')
+        component_group='main_dish')
     com_4.save()
     com_5 = Component(
         name='Fish chowder',
-        component_group='main dish')
+        component_group='main_dish')
     com_5.save()
     com_6 = Component(
         name='Ginger pork',
-        component_group='main dish')
+        component_group='main_dish')
     com_6.save()
     com_7 = Component(
         name='Beef Meatloaf',
-        component_group='main dish')
+        component_group='main_dish')
     com_7.save()
     com_8 = Component(
         name='Day s Dessert',
@@ -217,11 +217,11 @@ def insert_all():
     com_9.save()
     com_10 = Component(
         name='Fruit Salad',
-        component_group='fruit salad')
+        component_group='fruit_salad')
     com_10.save()
     com_11 = Component(
         name='Green Salad',
-        component_group='green salad')
+        component_group='green_salad')
     com_11.save()
     com_12 = Component(
         name='Lemon Pudding',
@@ -475,11 +475,11 @@ def insert_all():
         gender='M',
         birthdate=datetime.date(1940, 2, 23))
     cli_1.save()
-    cli_1.set_meal_defaults('main dish', 4, 2, 'L')
+    cli_1.set_meal_defaults('main_dish', 4, 2, 'L')
     cli_1.set_meal_defaults('dessert', 4, 1, '')
     cli_1.set_meal_defaults('diabetic dessert', 4, 0, '')
-    cli_1.set_meal_defaults('fruit salad', 4, 0, '')
-    cli_1.set_meal_defaults('green salad', 4, 1, '')
+    cli_1.set_meal_defaults('fruit_salad', 4, 0, '')
+    cli_1.set_meal_defaults('green_salad', 4, 1, '')
     cli_1.set_meal_defaults('pudding', 4, 1, '')
     cli_1.set_meal_defaults('compote', 4, 0, '')
     cli_1.save()
@@ -496,11 +496,11 @@ def insert_all():
         gender='M',
         birthdate=datetime.date(1945, 12, 13))
     cli_2.save()
-    cli_2.set_meal_defaults('main dish', 4, 1, 'R')
+    cli_2.set_meal_defaults('main_dish', 4, 1, 'R')
     cli_2.set_meal_defaults('dessert', 4, 1, '')
     cli_2.set_meal_defaults('diabetic dessert', 4, 0, '')
-    cli_2.set_meal_defaults('fruit salad', 4, 0, '')
-    cli_2.set_meal_defaults('green salad', 4, 0, '')
+    cli_2.set_meal_defaults('fruit_salad', 4, 0, '')
+    cli_2.set_meal_defaults('green_salad', 4, 0, '')
     cli_2.set_meal_defaults('pudding', 4, 0, '')
     cli_2.set_meal_defaults('compote', 4, 0, '')
     cli_2.save()
@@ -517,11 +517,11 @@ def insert_all():
         gender='M',
         birthdate=datetime.date(1943, 12, 13))
     cli_3.save()
-    cli_3.set_meal_defaults('main dish', 4, 2, 'R')
+    cli_3.set_meal_defaults('main_dish', 4, 2, 'R')
     cli_3.set_meal_defaults('dessert', 4, 0, '')
     cli_3.set_meal_defaults('diabetic dessert', 4, 0, '')
-    cli_3.set_meal_defaults('fruit salad', 4, 0, '')
-    cli_3.set_meal_defaults('green salad', 4, 2, '')
+    cli_3.set_meal_defaults('fruit_salad', 4, 0, '')
+    cli_3.set_meal_defaults('green_salad', 4, 2, '')
     cli_3.set_meal_defaults('pudding', 4, 0, '')
     cli_3.set_meal_defaults('compote', 4, 0, '')
     cli_3.save()
@@ -538,11 +538,11 @@ def insert_all():
         gender='M',
         birthdate=datetime.date(1943, 12, 13))
     cli_4.save()
-    cli_4.set_meal_defaults('main dish', 4, 1, 'L')
+    cli_4.set_meal_defaults('main_dish', 4, 1, 'L')
     cli_4.set_meal_defaults('dessert', 4, 0, '')
     cli_4.set_meal_defaults('diabetic dessert', 4, 0, '')
-    cli_4.set_meal_defaults('fruit salad', 4, 0, '')
-    cli_4.set_meal_defaults('green salad', 4, 0, '')
+    cli_4.set_meal_defaults('fruit_salad', 4, 0, '')
+    cli_4.set_meal_defaults('green_salad', 4, 0, '')
     cli_4.set_meal_defaults('pudding', 4, 0, '')
     cli_4.set_meal_defaults('compote', 4, 1, '')
     cli_4.save()

--- a/django/santropolFeast/meal/factories.py
+++ b/django/santropolFeast/meal/factories.py
@@ -1,17 +1,103 @@
 # coding=utf-8
 
 import factory
-from meal.models import Ingredient
+import random
+from django.db import models
+from faker import Factory as FakerFactory
+from meal.models import (
+    Ingredient, Component, Component_ingredient, Incompatibility,
+    Restricted_item, INGREDIENT_GROUP_CHOICES, COMPONENT_GROUP_CHOICES,
+    RESTRICTED_ITEM_GROUP_CHOICES, Menu, Menu_component
+)
+
+fake = FakerFactory.create()
 
 
 class IngredientFactory(factory.DjangoModelFactory):
+
     class Meta:
         model = Ingredient
 
-    name = "Tomato"
+    name = fake.word()
 
-    @classmethod
-    def __init__(self, **kwargs):
-        name = kwargs.pop('name', None)
-        ingredients = super(IngredientFactory, self).__init__(self, **kwargs)
-        ingredients.save()
+    description = fake.sentence(nb_words=10, variable_nb_words=True)
+
+    ingredient_group = factory.LazyAttribute(
+        lambda x: random.choice(INGREDIENT_GROUP_CHOICES)[0]
+    )
+
+
+class ComponentFactory(factory.DjangoModelFactory):
+
+    class Meta:
+        model = Component
+
+    name = fake.word()
+
+    description = fake.sentence(nb_words=10, variable_nb_words=True)
+
+    component_group = factory.LazyAttribute(
+        lambda x: random.choice(COMPONENT_GROUP_CHOICES)[0]
+    )
+
+
+class ComponentIngredientFactory(factory.DjangoModelFactory):
+
+    class Meta:
+        model = Component_ingredient
+
+    component = factory.SubFactory(ComponentFactory)
+
+    ingredient = factory.SubFactory(IngredientFactory)
+
+
+class RestrictedItemFactory(factory.DjangoModelFactory):
+
+    class Meta:
+        model = Restricted_item
+
+    name = fake.word()
+
+    description = fake.sentence(nb_words=10, variable_nb_words=True)
+
+    restricted_item_group = factory.LazyAttribute(
+        lambda x: random.choice(RESTRICTED_ITEM_GROUP_CHOICES)[0]
+    )
+
+
+class IncompatibilityFactory(factory.DjangoModelFactory):
+
+    class Meta:
+        model = Incompatibility
+
+    restricted_item = factory.SubFactory(RestrictedItemFactory)
+
+    ingredient = factory.SubFactory(Ingredient)
+
+
+class MenuFactory(factory.DjangoModelFactory):
+
+    class Meta:
+        model = Menu
+
+    date = factory.LazyAttribute(lambda x: fake.date_time_between(
+            start_date="-1y",
+            end_date="+1y",
+            tzinfo=None
+        )
+    )
+
+    menu_component = factory.RelatedFactory(
+        'meal.factories.MenuComponentFactory',
+        'menu'
+    )
+
+
+class MenuComponentFactory(factory.DjangoModelFactory):
+
+    class Meta:
+        model = Menu_component
+
+    menu = factory.SubFactory(MenuFactory)
+
+    component = factory.SubFactory(ComponentFactory)

--- a/django/santropolFeast/meal/models.py
+++ b/django/santropolFeast/meal/models.py
@@ -18,7 +18,7 @@ INGREDIENT_GROUP_CHOICES = (
     ('dairy', _('Dairy')),
     ('fish', _('Fish')),
     ('seafood', _('Seafood')),
-    ('veggies and fruits', _('Veggies and fruits')),
+    ('veggies_and_fruits', _('Veggies and fruits')),
     ('legumineuse', _('Legumineuse')),
     ('grains', _('Grains')),
     ('fresh_herbs', _('Fresh herbs')),

--- a/django/santropolFeast/meal/models.py
+++ b/django/santropolFeast/meal/models.py
@@ -2,11 +2,11 @@ from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
 COMPONENT_GROUP_CHOICES = (
-    ('main dish', _('Main dish')),
+    ('main_dish', _('Main Dish')),
     ('dessert', _('Dessert')),
-    ('diabetic dessert', _('Diabetic dessert')),
-    ('fruit salad', _('Fruit salad')),
-    ('green salad', _('Green salad')),
+    ('diabetic', _('Diabetic Dessert')),
+    ('fruit_salad', _('Fruit Salad')),
+    ('green_salad', _('Green Salad')),
     ('pudding', _('Pudding')),
     ('compote', _('Compote')),
 )
@@ -21,10 +21,10 @@ INGREDIENT_GROUP_CHOICES = (
     ('veggies and fruits', _('Veggies and fruits')),
     ('legumineuse', _('Legumineuse')),
     ('grains', _('Grains')),
-    ('fresh herbs', _('Fresh herbs')),
+    ('fresh_herbs', _('Fresh herbs')),
     ('spices', _('Spices')),
-    ('dry and canned goods', _('Dry and canned goods')),
-    ('oils and sauces', _('Oils and sauces')),
+    ('dry_and_canned_goods', _('Dry and canned goods')),
+    ('oils_and_sauces', _('Oils and sauces')),
 )
 
 RESTRICTED_ITEM_GROUP_CHOICES = (

--- a/django/santropolFeast/member/factories.py
+++ b/django/santropolFeast/member/factories.py
@@ -1,10 +1,12 @@
 # coding=utf-8
 import factory
-import datetime
 import random
-from django.contrib.auth.models import User
-from member.models import Member, Address, Contact, Client, PAYMENT_TYPE, Route
-from member.models import DELIVERY_TYPE, GENDER_CHOICES
+from member.models import (
+    Member, Client, Contact, Route, Address, Referencing,
+    CONTACT_TYPE_CHOICES, GENDER_CHOICES, PAYMENT_TYPE,
+    DELIVERY_TYPE, DAYS_OF_WEEK, RATE_TYPE
+)
+from meal.models import COMPONENT_GROUP_CHOICES
 
 
 class AddressFactory (factory.DjangoModelFactory):
@@ -45,6 +47,14 @@ class RouteFactory(factory.DjangoModelFactory):
     name = factory.Faker('name')
 
 
+def generate_json():
+    json = {}
+    for day, translation in DAYS_OF_WEEK:
+        for meal, Meal in COMPONENT_GROUP_CHOICES:
+            json['{}_{}_quantity'.format(meal, day)] = random.choice([0, 1])
+    return json
+
+
 class ClientFactory (factory.DjangoModelFactory):
 
     class Meta:
@@ -53,17 +63,53 @@ class ClientFactory (factory.DjangoModelFactory):
     member = factory.SubFactory(MemberFactory)
     billing_member = member
     billing_payment_type = factory.LazyAttribute(
-        lambda x: random.choice(PAYMENT_TYPE)[0])
-    rate_type = "default"
+        lambda x: random.choice(PAYMENT_TYPE)[0]
+    )
+    rate_type = factory.LazyAttribute(
+        lambda x: random.choice(RATE_TYPE)[0]
+    )
     member = member
     emergency_contact = factory.SubFactory(MemberFactory)
+    emergency_contact_relationship = factory.LazyAttribute(
+        lambda x: random.choice(['friends', 'family', 'coworkers'])
+    )
     status = factory.LazyAttribute(
         lambda x: random.choice(
-            Client.CLIENT_STATUS)[0])
-    language = "en"
+            Client.CLIENT_STATUS)[0]
+    )
+    language = factory.LazyAttribute(
+        lambda x: random.choice(
+            Client.LANGUAGES)[0]
+    )
     alert = factory.Faker('sentence')
     delivery_type = factory.LazyAttribute(
-        lambda x: random.choice(DELIVERY_TYPE)[0])
-    gender = factory.LazyAttribute(lambda x: random.choice(GENDER_CHOICES)[0])
+        lambda x: random.choice(DELIVERY_TYPE)[0]
+    )
+    gender = factory.LazyAttribute(
+        lambda x: random.choice(GENDER_CHOICES)[0]
+    )
     birthdate = factory.Faker('date')
-    route = factory.LazyAttribute(lambda x: random.choice(Route.objects.all()))
+    route = factory.SubFactory(RouteFactory)
+
+    meal_default_week = factory.LazyAttribute(lambda x: generate_json())
+
+    referencing = factory.RelatedFactory(
+        'member.factories.ReferencingFactory',
+        'client'
+    )
+
+
+class ReferencingFactory(factory.DjangoModelFactory):
+
+    class Meta:
+        model = Referencing
+
+    referent = factory.SubFactory(MemberFactory)
+
+    client = factory.SubFactory(ClientFactory)
+
+    referral_reason = factory.Faker('sentence')
+
+    work_information = factory.Faker('company')
+
+    date = factory.Faker('date')

--- a/django/santropolFeast/member/forms.py
+++ b/django/santropolFeast/member/forms.py
@@ -1,13 +1,13 @@
 from django import forms
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils.translation import ugettext_lazy as _
+from meal.models import Ingredient, Component, COMPONENT_GROUP_CHOICES
+from order.models import SIZE_CHOICES
 from member.models import (
     Member, Client, RATE_TYPE, CONTACT_TYPE_CHOICES,
     GENDER_CHOICES, PAYMENT_TYPE, DELIVERY_TYPE,
     DAYS_OF_WEEK
 )
-from meal.models import Ingredient, Component
-from order.models import SIZE_CHOICES
 
 
 class ClientBasicInformation (forms.Form):
@@ -94,33 +94,22 @@ class ClientRestrictionsInformation(forms.Form):
     def __init__(self, *args, **kwargs):
         super(ClientRestrictionsInformation, self).__init__(*args, **kwargs)
 
-        day_of_week = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday',
-                       'saturday', 'sunday']
-        meals_placeholders = (
-            ('main_dish', _('Main Dish')),
-            ('dessert', _('Dessert')),
-            ('diabetic', _('Diabetic Dessert')),
-            ('fruit_salad', _('Fruit Salad')),
-            ('green_salad', _('Green Salad')),
-            ('pudding', _('Pudding')),
-            ('compote', _('Compote')),
-            )
-
-        for day in day_of_week:
-
+        for day in DAYS_OF_WEEK:
             self.fields['size_{}'.format(day)] = forms.ChoiceField(
                 choices=SIZE_CHOICES,
                 widget=forms.Select(attrs={'class': 'ui dropdown'}),
                 required=False
                 )
 
-            for meal, placeholder in meals_placeholders:
-                self.fields[
-                    '{}_{}_quantity'.format(meal, day)
-                ] = forms.IntegerField(
-                    widget=forms.TextInput(attrs={'placeholder': placeholder}),
-                    required=False
+            for meal, placeholder in COMPONENT_GROUP_CHOICES:
+                self.fields['{}_{}_quantity'.format(meal, day)] = \
+                    forms.IntegerField(
+                        widget=forms.TextInput(
+                            attrs={'placeholder': placeholder}
+                        ),
+                        required=False
                     )
+
     status = forms.BooleanField(
         label=_('Active'),
         help_text=_('By default, the client meal status is Pending.'),

--- a/django/santropolFeast/member/management/commands/createclients.py
+++ b/django/santropolFeast/member/management/commands/createclients.py
@@ -1,15 +1,14 @@
-import factory
-from django.core.management.base import BaseCommand, CommandError
-from member.models import Member as Member
-from member.factories import MemberFactory, ClientFactory
+from django.core.management.base import BaseCommand
+from member.factories import ClientFactory
 
 
 class Command(BaseCommand):
-    help = 'Creates a happy bunch of clients and orders'
+    help = 'Creates a happy bunch of clients without orders'
 
     def handle(self, *args, **options):
         client = ClientFactory.create_batch(10)
         self.stdout.write(
             self.style.SUCCESS(
-                'Successfully created client "%s"' %
-                client))
+                'Successfully created client "%s"' % client
+            )
+        )

--- a/django/santropolFeast/member/tests.py
+++ b/django/santropolFeast/member/tests.py
@@ -504,7 +504,7 @@ class FormTestCase(TestCase):
             "client_wizard-current_step": "dietary_restriction",
             "dietary_restriction-status": "on",
             "dietary_restriction-delivery_type": "O",
-            "dietary_restriction-delivery_schedule": "mon",
+            "dietary_restriction-delivery_schedule": "monday",
             "dietary_restriction-meal_default": "1",
             "wizard_goto_step": ""
         }
@@ -701,7 +701,7 @@ class FormTestCase(TestCase):
             "client_wizard-current_step": "dietary_restriction",
             "dietary_restriction-status": "on",
             "dietary_restriction-delivery_type": "O",
-            "dietary_restriction-delivery_schedule": "mon",
+            "dietary_restriction-delivery_schedule": "monday",
             "dietary_restriction-meal_default": "1",
             "wizard_goto_step": ""
         }
@@ -1229,7 +1229,7 @@ class FormTestCase(TestCase):
             "client_wizard-current_step": "dietary_restriction",
             "dietary_restriction-status": "on",
             "dietary_restriction-delivery_type": "O",
-            "dietary_restriction-delivery_schedule": "mon",
+            "dietary_restriction-delivery_schedule": "monday",
             "dietary_restriction-meal_default": "1",
             "wizard_goto_step": ""
         }

--- a/django/santropolFeast/member/views.py
+++ b/django/santropolFeast/member/views.py
@@ -3,27 +3,16 @@
 from django.views import generic
 from django.utils.decorators import method_decorator
 from django.http import HttpResponseRedirect, JsonResponse
-from django.core.urlresolvers import reverse_lazy
 from django.shortcuts import get_object_or_404
 from django.contrib.auth.decorators import login_required
 from django.db.models import Q
-from member.models import Client, Member, Address, Contact, Note
-from member.models import Referencing, ClientFilter, Note, ClientFilter
+from member.models import (
+    Client, Member, Address, Contact, Note, Referencing,
+    ClientFilter, Note, ClientFilter, DAYS_OF_WEEK
+)
+from meal.models import COMPONENT_GROUP_CHOICES
 from formtools.wizard.views import NamedUrlSessionWizardView
-from django.shortcuts import render
 from django.core.urlresolvers import reverse_lazy
-
-size = ['regular', 'large']
-
-meals = ['main_dish', 'dessert', 'diabetic', 'fruit_salad',
-         'green_salad', 'pudding', 'compote']
-
-day_of_week = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday',
-               'saturday', 'sunday']
-
-meals_template = ['main_dish', 'dessert', 'diabetic', 'fruit_salad',
-                  'green_salad'
-                  ]
 
 
 class ClientWizard(NamedUrlSessionWizardView):
@@ -33,17 +22,15 @@ class ClientWizard(NamedUrlSessionWizardView):
     def get_context_data(self, **kwargs):
         context = super(ClientWizard, self).get_context_data(**kwargs)
 
-        context["weekday"] = day_of_week
-        context["meals"] = meals_template
-        context["size"] = size
+        context["weekday"] = DAYS_OF_WEEK
+        context["meals"] = COMPONENT_GROUP_CHOICES
 
         return context
 
     def save_json(self, dictonary):
-
         json = {}
 
-        for days in day_of_week:
+        for days, Days in DAYS_OF_WEEK:
             json['size_{}'.format(days)] = dictonary.cleaned_data.get(
                 'size_{}'.format(days)
             )
@@ -51,7 +38,7 @@ class ClientWizard(NamedUrlSessionWizardView):
             if json['size_{}'.format(days)] is "":
                 json['size_{}'.format(days)] = None
 
-            for meal in meals:
+            for meal, Meals in COMPONENT_GROUP_CHOICES:
                 json['{}_{}_quantity'.format(meal, days)] \
                     = dictonary.cleaned_data.get(
                     '{}_{}_quantity'.format(meal, days)

--- a/django/santropolFeast/order/factories.py
+++ b/django/santropolFeast/order/factories.py
@@ -1,20 +1,75 @@
 # coding=utf-8
 import factory
+import random
+from faker import Factory as FakerFactory
 from member.factories import MemberFactory, ClientFactory
-from order.models import Order, Order_item
+from order.models import (
+    Order, Order_item, ORDER_STATUS_CHOICES, ORDER_ITEM_TYPE_CHOICES
+)
+from meal.factories import ComponentFactory
+from order.models import SIZE_CHOICES
 
-from datetime import datetime
+
+fake = FakerFactory.create()
 
 
 class OrderFactory(factory.DjangoModelFactory):
     class Meta:
         model = Order
 
-    creation_date = datetime.now()
-    delivery_date = datetime.now()
+    creation_date = factory.LazyAttribute(
+        lambda x: fake.date_time_between(
+            start_date="-1y",
+            end_date="+1y",
+            tzinfo=None
+        )
+    )
+
+    delivery_date = factory.LazyAttribute(
+        lambda x: fake.date_time_between(
+            start_date="-1y",
+            end_date="+1y",
+            tzinfo=None
+        )
+    )
+
+    status = factory.LazyAttribute(
+        lambda x: random.choice(ORDER_STATUS_CHOICES)[0]
+    )
+
     client = factory.SubFactory(ClientFactory)
+
+    order_item = factory.RelatedFactory(
+        'order.factories.OrderItemFactory',
+        'order'
+    )
 
 
 class OrderItemFactory(factory.DjangoModelFactory):
     class Meta:
         model = Order_item
+
+    order = factory.SubFactory(OrderFactory)
+
+    component = factory.SubFactory(ComponentFactory)
+
+    price = fake.random_int(min=0, max=50)
+
+    billable_flag = fake.random_sample(
+        elements=(True, False),
+        length=None
+    )
+
+    size = factory.LazyAttribute(
+        lambda x: random.choice(SIZE_CHOICES)[0]
+    )
+
+    order_item_type = factory.LazyAttribute(
+        lambda x: random.choice(ORDER_ITEM_TYPE_CHOICES)[0]
+    )
+
+    remark = fake.sentence(nb_words=6, variable_nb_words=True)
+
+    total_quantity = fake.random_digit()
+
+    free_quantity = fake.random_digit()

--- a/django/santropolFeast/order/management/commands/createorders.py
+++ b/django/santropolFeast/order/management/commands/createorders.py
@@ -1,0 +1,14 @@
+from django.core.management.base import BaseCommand
+from order.factories import OrderFactory
+
+
+class Command(BaseCommand):
+    help = 'Creates a happy bunch of clients with orders'
+
+    def handle(self, *args, **options):
+        orders = OrderFactory.create_batch(10)
+        self.stdout.write(
+            self.style.SUCCESS(
+                'Successfully created client {} orders'.format(orders)
+            )
+        )

--- a/django/santropolFeast/order/management/commands/generateorders.py
+++ b/django/santropolFeast/order/management/commands/generateorders.py
@@ -1,0 +1,34 @@
+from django.core.management.base import BaseCommand
+from order.models import Order
+from member.models import Client
+from meal.factories import MenuFactory
+from datetime import datetime
+
+
+class Command(BaseCommand):
+    help = 'Generate orders for all clients using his preferences'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--creation_date',
+            help='The date must be in the format YYYY-MM-DD',
+        )
+        parser.add_argument(
+            'delivery_date',
+            help='The date must be in the format YYYY-MM-DD',
+        )
+
+    def handle(self, *args, **options):
+        print(options['creation_date'])
+        if options['creation_date']:
+            creation_date = datetime.strptime(
+                options['creation_date'], '%Y-%m-%d'
+            )
+        else:
+            creation_date = datetime.now()
+        delivery_date = datetime.strptime(
+            options['delivery_date'], '%Y-%m-%d'
+        )
+        clients = Client.objects.all()
+        MenuFactory.create(date=delivery_date)
+        Order.create_orders_on_defaults(creation_date, delivery_date, clients)

--- a/django/santropolFeast/order/models.py
+++ b/django/santropolFeast/order/models.py
@@ -180,7 +180,7 @@ class Order(models.Model):
                     else:
                         unit_price = side_price
                         while free_side_dish_qty > 0 and default_qty > 0:
-                            free_side_dish_qty -= - 1
+                            free_side_dish_qty -= 1
                             default_qty -= 1
                             free_quantity += 1
                     oi = Order_item(

--- a/django/santropolFeast/order/models.py
+++ b/django/santropolFeast/order/models.py
@@ -7,8 +7,6 @@ from meal.models import COMPONENT_GROUP_CHOICES_MAIN_DISH
 from django.utils.translation import ugettext_lazy as _
 from django_filters import FilterSet, MethodFilter, ChoiceFilter
 from member.apps import MemberConfig
-import re
-import datetime
 
 ORDER_STATUS_CHOICES = (
     ('O', _('Ordered')),
@@ -104,6 +102,7 @@ class Order(models.Model):
             self.delivery_date
         )
 
+    @staticmethod
     def create_orders_on_defaults(creation_date, delivery_date, clients):
         """Create orders and order items for one or many clients.
 
@@ -147,8 +146,7 @@ class Order(models.Model):
             if free_side_dish_qty == 0:
                 continue  # No meal for client on this day
             try:
-                order = Order.objects.get(
-                    client=client, delivery_date=delivery_date)
+                Order.objects.get(client=client, delivery_date=delivery_date)
                 # order already created, skip order items creation
                 # (if want to replace, must be deleted first)
                 continue
@@ -158,7 +156,7 @@ class Order(models.Model):
                               delivery_date=delivery_date,
                               status=ORDER_STATUS_CHOICES_ORDERED)
                 order.save()
-                num_orders_created = num_orders_created + 1
+                num_orders_created += 1
             # TODO Use Parameters Model in member to store unit prices
             if client.rate_type == RATE_TYPE_LOW_INCOME:
                 main_price = MAIN_PRICE_LOW_INCOME
@@ -182,9 +180,9 @@ class Order(models.Model):
                     else:
                         unit_price = side_price
                         while free_side_dish_qty > 0 and default_qty > 0:
-                            free_side_dish_qty = free_side_dish_qty - 1
-                            default_qty = default_qty - 1
-                            free_quantity = free_quantity + 1
+                            free_side_dish_qty -= - 1
+                            default_qty -= 1
+                            free_quantity += 1
                     oi = Order_item(
                         order=order,
                         component=component,
@@ -214,7 +212,8 @@ class OrderFilter(FilterSet):
         model = Order
         fields = ['status', 'delivery_date']
 
-    def filter_search(self, queryset, value):
+    @staticmethod
+    def filter_search(queryset, value):
         if not value:
             return queryset
 
@@ -234,9 +233,7 @@ class OrderFilter(FilterSet):
             )
             name_contains |= lastname_contains
 
-        return queryset.filter(
-            name_contains
-        )
+        return queryset.filter(name_contains)
 
 
 class Order_item(models.Model):


### PR DESCRIPTION
### Changes proposed in this pull request:

* Update ClientFactory to add new fields like the json meals_default_week
and create ReferencingFactory
* Reuse the same constants COMPONENT_GROUP_CHOICES and DAYS_OF_WEEK in all
classes and remove duplication
* Update the command createclients
* Add the commands createorders and generateorders. The command createorders
will create new client and orders with ramdom data. The command generateorders
will create orders for the existing clients preferences of meal_default_week.
* Update tests files to the previous changes made.
* Update dataload.py because the component groups names has changed.

### Status

- [X] READY


