### PR TITLE
fix 241 Allow ingredient selection for the day (initial version)

### DIFF
--- a/django/santropolFeast/delivery/forms.py
+++ b/django/santropolFeast/delivery/forms.py
@@ -1,6 +1,41 @@
 from django import forms
+from django.utils.translation import ugettext_lazy as _
+from django.contrib.admin.widgets import FilteredSelectMultiple
 
 
 class DateForm(forms.Form):
     date = forms.DateField(
         label=' ', widget=forms.SelectDateWidget)
+
+
+class DayIngredientsForm(forms.Form):
+    def __init__(self, *args, **kwargs):
+        try:
+            self.choices = kwargs.pop('choices')
+        except KeyError:
+            raise KeyError("DayIngredientsForm missing kwarg : choices")
+        super().__init__(*args, **kwargs)
+        self.fields['ingredients'].choices = self.choices
+
+    ingredients = forms.MultipleChoiceField(
+        label=_('Ingredients'),
+        widget=FilteredSelectMultiple(
+            'Ingredients', is_stacked=False, attrs={'rows': '10'}),
+        required=False,
+    )
+
+    date = forms.DateField(
+        label=' ',
+        widget=forms.HiddenInput,
+        required=False,
+    )
+
+    dish = forms.CharField(
+        label=' ',
+        widget=forms.HiddenInput,
+        required=False,
+    )
+
+    class Media:
+        css = {'all': ('/static/admin/css/widgets.css', ), }
+        js = ('/admin/jsi18n', )

--- a/django/santropolFeast/delivery/templates/ingredients.html
+++ b/django/santropolFeast/delivery/templates/ingredients.html
@@ -5,35 +5,45 @@
 {% block title %}{% trans 'Kitchen Count report' %} {% endblock %}
 
 {% block extrajs %}
-<script type="text/javascript">
-    $('.ui.dropdown').dropdown({transition: 'drop'});
-</script>
+    <script type="text/javascript">
+     $('.ui.dropdown').dropdown({transition: 'drop'});
+    </script>
 {% endblock %}
 
 {% block content %}
 
-{% include 'kitchen_count_steps.html' with step='ingredients' %}
+    {% include 'kitchen_count_steps.html' with step='ingredients' %}
 
-<div class="ui secondary pointing fluid menu">
-    <h2 class="ui header">Pick ingredients</h2>
-    <div class="right menu">
-      <div class="ui item"><h3><i class="ui calendar icon"></i>{% now "j F Y" %}</h3></div>
+    <div class="ui secondary pointing fluid menu">
+        <h2 class="ui header">Pick ingredients</h2>
+        <div class="right menu">
+            <div class="ui item"><h3><i class="ui calendar icon"></i>{{ date }}</h3></div>
+        </div>
     </div>
-</div>
 
-<div class="ui search selection dropdown">
-  <input type="hidden" name="ingredients">
-  <i class="dropdown icon"></i>
-  <div class="default text">What should we eat today ?</div>
-  <div class="menu">
-      {% for meal in meals %}
-      <div class="item" data-value="{{ meal.id }}">{{ meal.name }}</div>
-      {% endfor %}
-  </div>
-</div>
+    <div class="ui basic big label">
+        Delivery Date :
+    </div>
+    <form class="ui input" action="{% url 'delivery:meal' %}" method="post">
+        {% csrf_token %}
+        {{ date_form }}
+        <input class="ui button" type="submit" value="Change" name="_change" />
+    </form>
+    <div class="ui basic big label">
+        Main dish : {{ main_dish_name }}
+    </div>
 
- <div class="ui row">
-     <a class="big ui right floated button" href="{% url 'delivery:order' %}">Back</a>
-     <a class="big ui yellow right floated button" href="{% url 'delivery:kitchen_count' %}">Next: Print Kitchen Count</a>
+<div>
+    <script type="text/javascript" src="/static/admin/js/jquery.min.js"></script>
+    <script type="text/javascript" src="/static/admin/js/jquery.init.js"></script>
+    {{ ing_form.media }}
+    <form class="ui input" action="{% url 'delivery:meal' %}" method="post">
+        {% csrf_token %}
+        {{ ing_form.ingredients }}
+        {{ ing_form.date }}
+        {{ ing_form.dish }}
+        <input class="ui right floated button" type="submit" value="Back" name="_back" </>
+        <input class="ui yellow right floated button" type="submit" value="Next: Print Kitchen Count" name="_next" </>
+    </form>
 </div>
 {% endblock content %}

--- a/django/santropolFeast/delivery/templates/kitchen_count.html
+++ b/django/santropolFeast/delivery/templates/kitchen_count.html
@@ -21,7 +21,7 @@
 <form class="ui input" action="{% url 'delivery:kitchen_count' %}" method="post">
     {% csrf_token %}
     {{ form }}
-    <input class="ui button" type="submit" value="Change" />
+    <input class="ui button" type="submit" value="Change" name="_change" />
 </form>
 <table class="ui very compact table">
   <thead>
@@ -74,6 +74,6 @@
   </tbody>
 </table>
 
-<a class="big ui right floated button" href="{% url 'delivery:meal' %}">Back</a>
+<a class="big ui right floated button" href="{{request.META.HTTP_REFERER}}">Back</a>
 <a class="big ui yellow right floated button" href="{% url 'delivery:route' %}">Next: Organize Routes</a>
 {% endblock %}

--- a/django/santropolFeast/delivery/tests.py
+++ b/django/santropolFeast/delivery/tests.py
@@ -13,3 +13,64 @@ class KitchenCountReportTestCase(TestCase):
         """An ingredient we know will clash must be in the page"""
         response = self.client.get('/delivery/kitchen_count/2016/05/21/')
         self.assertTrue(b'Ground porc' in response.content)
+
+
+class ChooseDayMainDishIngredientsTestCase(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        # This data set includes 'Ground porc' main dish ingredient
+        #  for 2016-05-21
+        # This data set includes 'Pepper' available ingredient
+        insert_all()  # load fresh data into DB
+
+    def test_known_ingredients(self):
+        """Two ingredients we know must be in the page"""
+        response = self.client.get('/delivery/meal/2016/05/21/')
+        self.assertTrue(b'Ground porc' in response.content and
+                        b'Pepper' in response.content)
+
+    def test_no_main_dish_on_date(self):
+        """No main dish on this date"""
+        response = self.client.get('/delivery/meal/2016/05/01/')
+        self.assertTrue(b'None for chosen date' in response.content)
+
+    def test_change_date_with_dish(self):
+        """Change main dish date."""
+        response = self.client.get('/delivery/meal/')
+        response = self.client.post(
+            '/delivery/meal/',
+            {'_change': 'Change',
+             'date_year': '2016',
+             'date_month': '5',
+             'date_day': '21'})
+        self.assertTrue('2016/05/21' in response.url)
+
+    def test_date_with_dish_next(self):
+        """From ingredient choice go to Kitchen Count Report."""
+        response = self.client.get('/delivery/meal/2016/05/21/')
+        response = self.client.post(
+            '/delivery/meal/',
+            {'_next': 'Next: Print Kitchen Count',
+             'date': '2016-05-21',
+             'dish': 'Ginger pork',
+             'ingredients': ['Onion', 'Ground porc', 'soy sauce',
+                             'green peppers', 'sesame seeds', 'celery']})
+        self.assertTrue('/delivery/kitchen_count/2016/05/21' in response.url)
+
+    def test_date_with_dish_back(self):
+        """From ingredient choice go to Orders."""
+        response = self.client.get('/delivery/meal/2016/05/21/')
+        response = self.client.post('/delivery/meal/', {'_back': 'Back'})
+        self.assertTrue('/delivery/order/' in response.url)
+
+    def test_post_invalid_form(self):
+        """Invalid form."""
+        response = self.client.get('/delivery/meal/')
+        response = self.client.post(
+            '/delivery/meal/',
+            {'_change': 'Change',
+             'date_year': '2016',
+             'date_month': '5',
+             'date_day': '0'})
+        self.assertTrue(b'Ingredients' in response.content)

--- a/django/santropolFeast/delivery/urls.py
+++ b/django/santropolFeast/delivery/urls.py
@@ -10,11 +10,12 @@ from delivery.views import routeDailyOrders
 urlpatterns = [
     url(_(r'^order/$'), Orderlist.as_view(), name='order'),
     url(_(r'^meal/$'), MealInformation.as_view(), name='meal'),
+    url(_(r'^meal/(?P<year>\d{4})/(?P<month>\d{2})/(?P<day>\d+)/$'),
+        MealInformation.as_view(), name='meal_date'),
     url(_(r'^route/$'), RoutesInformation.as_view(), name='route'),
     url(_(r'^kitchen_count/$'), KitchenCount.as_view(), name='kitchen_count'),
     url(_(r'^kitchen_count/(?P<year>\d{4})/(?P<month>\d{2})/(?P<day>\d+)/$'),
         KitchenCount.as_view(), name='kitchen_count_date'),
-    # url(_(r'^kitchen_count/$'), kcr_view, name='route'),
     url(_(r'^getDailyOrders/$'), dailyOrders, name='dailyOrders'),
     url(_(r'^refresh_orders/$'), refreshOrders, name='refresh_orders'),
     url(_(r'^getDailyOrders/route[0-9]{1}/$'), routeDailyOrders,

--- a/django/santropolFeast/delivery/views.py
+++ b/django/santropolFeast/delivery/views.py
@@ -4,6 +4,7 @@ from django.shortcuts import render
 from django.views import generic
 from django.http import HttpResponseRedirect
 from django.utils.decorators import method_decorator
+from django.utils.translation import ugettext_lazy as _
 from django.contrib.auth.decorators import login_required
 from delivery.models import Delivery
 from django.http import JsonResponse
@@ -16,9 +17,11 @@ from .apps import DeliveryConfig
 from sqlalchemy import func, or_, and_
 
 from .models import Delivery
-from .forms import DateForm
+from .forms import DateForm, DayIngredientsForm
 from order.models import Order
-from meal.models import COMPONENT_GROUP_CHOICES_MAIN_DISH, Component
+from meal.models import (
+    COMPONENT_GROUP_CHOICES_MAIN_DISH, Component, Ingredient, Menu_component,
+    Component_ingredient)
 from member.apps import db_session
 from member.models import Client, Route
 from datetime import date
@@ -35,17 +38,104 @@ class Orderlist(generic.ListView):
         return queryset
 
 
-class MealInformation(generic.ListView):
-    # Display all the meal and alert for a given day
-    model = Delivery
-    template_name = 'ingredients.html'
+class MealInformation(generic.View):
 
-    def get_context_data(self, **kwargs):
+    def get(self, request, **kwargs):
+        # Choose ingredients for given delivery date
+        #   or for today by default
+        if 'year' in kwargs and 'month' in kwargs and 'day' in kwargs:
+            date = datetime.date(
+                int(kwargs['year']), int(kwargs['month']), int(kwargs['day']))
+        else:
+            date = datetime.date.today()
+        date_form = DateForm(initial={'date': date})
+        # TODO use managers
+        main_dishes = Menu_component.objects.filter(
+            menu__date=date,
+            component__component_group=COMPONENT_GROUP_CHOICES_MAIN_DISH)
+        if main_dishes:
+            main_dish_name = main_dishes[0].component.name
+            # get existing ingredients for the date + dish, if any
+            dish_ingredients = Component.get_day_ingredients(
+                    main_dishes[0].component.id, date)
+            if not dish_ingredients:
+                # get recipe ingredients for the dish
+                dish_ingredients = Component.get_recipe_ingredients(
+                    main_dishes[0].component.id)
+            all_ingredients = \
+                [ingredient.name for ingredient in Ingredient.objects.all()]
+            ing_form = DayIngredientsForm(
+                choices=[(a, a) for a in all_ingredients],
+                initial={'ingredients': dish_ingredients,
+                         'date': date,
+                         'dish': main_dish_name})
+        else:
+            main_dish_name = 'None for chosen date'
+            ing_form = DayIngredientsForm(choices=[])
+        return render(
+            request,
+            'ingredients.html',
+            {'date_form': date_form,
+             'date': str(date),
+             'main_dish_name': main_dish_name,
+             'ing_form': ing_form})
 
-        context = super(MealInformation, self).get_context_data(**kwargs)
-        context['meals'] = Component.objects.all()
-
-        return context
+    def post(self, request):
+        date_form = None
+        ing_form = None
+        main_dish_name = ''
+        # print("post request", request.POST)  # debug
+        if '_change' in request.POST:
+            # change date for day's ingredients
+            date_form = DateForm(request.POST)
+            if date_form.is_valid():
+                date = date_form.cleaned_data['date']
+                fmtdate = \
+                    '{:04}/{:02}/{:02}'.format(date.year, date.month, date.day)
+                return HttpResponseRedirect('/delivery/meal/' + fmtdate + '/')
+        elif '_back' in request.POST:
+            # back to order step
+            return HttpResponseRedirect('/delivery/order/')
+        elif '_next' in request.POST:
+            # forward to kitchen count
+            all_ingredients = \
+                [ingredient.name for ingredient in Ingredient.objects.all()]
+            ing_form = DayIngredientsForm(
+                request.POST, choices=[(a, a) for a in all_ingredients])
+            if ing_form.is_valid():
+                ingredients = ing_form.cleaned_data['ingredients']
+                date = ing_form.cleaned_data['date']
+                main_dish_name = ing_form.cleaned_data['dish']
+                component = Component.objects.get(name=main_dish_name)
+                # delete existing ingredients for the date + dish
+                Component_ingredient.objects.filter(
+                    component=component, date=date).delete()
+                # add revised ingredients for the date + dish
+                for ing in Ingredient.objects.filter(name__in=ingredients):
+                    ci = Component_ingredient(
+                        component=component,
+                        ingredient=ing,
+                        date=date)
+                    ci.save()
+                    # print("ci=", ci)  # DEBUG
+                fmtdate = \
+                    '{:04}/{:02}/{:02}'.format(date.year, date.month, date.day)
+                return HttpResponseRedirect(
+                    '/delivery/kitchen_count/' + fmtdate + '/')
+                # END FOR
+            # END IF
+        # END IF
+        if not date_form:
+            date_form = DateForm(request.POST)
+        if not ing_form:
+            ing_form = DayIngredientsForm(choices=[])
+        return render(
+            request,
+            'ingredients.html',
+            {'date_form': date_form,
+             'date': '',
+             'main_dish_name': main_dish_name,
+             'ing_form': ing_form})
 
 
 class RoutesInformation(generic.ListView):
@@ -68,7 +158,7 @@ class KitchenCount(generic.View):
     def get(self, request, **kwargs):
         # Display kitchen count report for given delivery date
         #   or for today by default
-        if 'year' in kwargs:
+        if 'year' in kwargs and 'month' in kwargs and 'day' in kwargs:
             date = datetime.date(
                 int(kwargs['year']), int(kwargs['month']), int(kwargs['day']))
         else:
@@ -91,8 +181,8 @@ class KitchenCount(generic.View):
             date = form.cleaned_data['date']
             fmtdate = \
                 '{:04}/{:02}/{:02}'.format(date.year, date.month, date.day)
-            return HttpResponseRedirect
-            ('/delivery/kitchen_count/' + fmtdate + '/')
+            return HttpResponseRedirect(
+                '/delivery/kitchen_count/' + fmtdate + '/')
         else:
             return render(request, 'kitchen_count.html',
                           {'component_lines': [],

--- a/django/santropolFeast/meal/models.py
+++ b/django/santropolFeast/meal/models.py
@@ -43,7 +43,8 @@ class Ingredient(models.Model):
     # Information about the ingredient (in the recipe of a component)
     name = models.CharField(
         max_length=50,
-        verbose_name=_('name')
+        verbose_name=_('name'),
+        unique=True,
     )
 
     description = models.TextField(
@@ -95,7 +96,13 @@ class Component(models.Model):
         of a component for the delivery date."""
         q = Component_ingredient.objects.\
             filter(component__id=component_id, date=delivery_date)
-        # print("query=", q.query)  # DEBUG
+        return [ci.ingredient for ci in q]
+
+    @staticmethod
+    def get_recipe_ingredients(component_id):
+        """Returns a list of the ingredients in the recipe of a component."""
+        q = Component_ingredient.objects.\
+            filter(component__id=component_id, date=None)
         return [ci.ingredient for ci in q]
 
 


### PR DESCRIPTION
*Fixes #241 ; later I will improve UI and refactor the business logic.*

### Major changes proposed in this pull request:

* delivery/forms.py : added DayIngredientsForm to handle ingredients choice
* delivery/templates/ingredients.html : modified to handle ingredients choice (UI css needs rework)
* delivery/views.py : added MealInformation view to handle date + ingredients view / choice / save

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### Deployment notes and migration

- [ ] Migration needed

To see results : 
python dataexec.py
python manage.py runserver
Browse to SousChef
Click "Kitchen Count" / "OK I'm Ready" to get to page /delivery/meal/
Set date 2016-05-21, click "Change", see main dish recipe, hover / click on widget to change ingredients
Click "Next - Print Kitchen Count", see ingredients today and clients clashes
Click "Back", can change ingredients and so on.

@savoirfairelinux/mll
