### PR TITLE
Add logging capability to the generate order

### DIFF
--- a/django/santropolFeast/delivery/templates/review_orders.html
+++ b/django/santropolFeast/delivery/templates/review_orders.html
@@ -16,7 +16,7 @@
     </div>
 </div>
 
-<div class="ui row"><i class="ui history icon"></i>Orders have been generated on 27 July 2016, at 03:00 am.</div>
+<div class="ui row"><i class="ui history icon"></i>Orders have been generated on {{refresh.action_time}}.</div>
 <div class="ui row"><a class="ui button" href="{% url 'delivery:refresh_orders' %}"><i class="ui refresh icon"></i>Refresh orders</a></div>
 
 <table class="ui very basic stripped celled table">

--- a/django/santropolFeast/order/management/commands/generateorders.py
+++ b/django/santropolFeast/order/management/commands/generateorders.py
@@ -3,6 +3,7 @@ from order.models import Order
 from member.models import Client
 from meal.factories import MenuFactory
 from datetime import datetime
+from django.contrib.admin.models import LogEntry, ADDITION, CHANGE
 
 
 class Command(BaseCommand):
@@ -31,6 +32,12 @@ class Command(BaseCommand):
         clients = Client.active.all()
         numorders = Order.create_orders_on_defaults(
             creation_date, delivery_date, clients)
+        LogEntry.objects.log_action(
+            user_id=1, content_type_id=1,
+            object_id="", object_repr="Generation of order for "+str(
+                datetime.now().strftime('%Y-%m-%d %H:%M')),
+            action_flag=ADDITION,
+        )
         print("On", creation_date,
               "created", numorders,
               "orders to be delivered on", delivery_date, ".")


### PR DESCRIPTION
*Fixes #279  .*

### Changes proposed in this pull request:

* Add logging to the django admin panel

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### Deployment notes and migration

- [ ] Migration needed

Fill me in ...

@savoirfairelinux/mll

