### PR TITLE
272 improve list behavior

### DIFF
--- a/django/santropolFeast/member/templates/client/list.html
+++ b/django/santropolFeast/member/templates/client/list.html
@@ -73,7 +73,7 @@
 </div>
 
 {% if display == 'block' %}
-
+  {% if clients %}
 <div class="ui cards">
     {% for obj in clients %}
     <a class="ui card" href="{% url 'member:client_information' pk=obj.id %}">
@@ -103,13 +103,17 @@
             </div>
         </div>
     </a>
-    {% empty %}
-        <p>Sorry, no result found.</p>
-    {% endfor %}
-</div>
 
+    {% endfor %}
+
+</div>
+{% else %}
+    <div class="ui row"><p>Sorry, no result found.</p></div>
+
+{% endif %}
 {% else %}
 
+{% if clients %}
 <table class="ui very basic stripped celled table">
     <thead>
         <tr>
@@ -129,9 +133,6 @@
             <td>{{ obj.route }}</td>
             <td>{{ obj.member.updated_at|date:"Y/m/d H:h:m"  }}</td>
         </tr>
-
-        {% empty %}
-            <p>Sorry, no result found.</p>
         {% endfor %}
     </tbody>
     <tfoot>
@@ -143,7 +144,9 @@
           </tr>
     </tfoot>
 </table>
-
+{% else %}
+  <div class="ui row"><p>Sorry, no result found.</p></div>
+{% endif %}
 {% endif %}
 
 {% if is_paginated %}

--- a/django/santropolFeast/order/templates/list.html
+++ b/django/santropolFeast/order/templates/list.html
@@ -54,7 +54,7 @@
   </div>
 </div>
 
-
+{% if order %}
 <table class="ui very basic stripped celled table">
   <thead>
     <th class="sorted descending">Order</th>
@@ -90,8 +90,19 @@
         </tr>
   </tfoot>
 </table>
+<<<<<<< 624d3955fddeaf057141dc575e2c316d0d782e59
 
 
+=======
+{% else %}
+    <div class="ui row"><p>Sorry, no result found.</p></div>
+  {% endif %}
+<script type="text/javascript">
+    document.addEventListener( 'DOMContentLoaded', function () {
+      $('table').tablesort();
+    })
+</script>
+>>>>>>> Fix formating with the order list when empty
 
 {% endblock %}
 


### PR DESCRIPTION
*Fixes #272 *

### Changes proposed in this pull request:

* Client list now has a standard empty message
* Order list now has a standard empty message


### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### Deployment notes and migration

- [ ] Migration needed


@savoirfairelinux/mll
