### PR TITLE
Changes in the tests to use setUpTestData() to load data shared by al…

### DIFF
--- a/django/santropolFeast/member/tests.py
+++ b/django/santropolFeast/member/tests.py
@@ -362,8 +362,9 @@ class ClientAvoidComponentTestCase(TestCase):
 
 class FormTestCase(TestCase):
 
-    def setUp(self):
-        self.admin = User.objects.create_superuser(
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin = User.objects.create_superuser(
             username='admin@example.com',
             email='admin@example.com',
             password='test1234'
@@ -381,8 +382,13 @@ class FormTestCase(TestCase):
             firstname='Second',
             lastname='Member'
         )
-        self.route = RouteFactory()
-        self.client.login(username='admin@example.com', password='test1234')
+        cls.route = RouteFactory()
+
+    def setUp(self):
+        self.client.login(username=self.admin.username, password='test1234')
+
+    def tearDown(self):
+        self.client.logout()
 
     def test_acces_to_form(self):
         """Test if the form is accesible from its url"""

--- a/django/santropolFeast/note/tests.py
+++ b/django/santropolFeast/note/tests.py
@@ -1,26 +1,24 @@
 from django.test import TestCase
-from member.models import Member, Client
 from note.models import Note
 from note.factories import NoteFactory
 from django.contrib.auth.models import User
 from member.factories import ClientFactory
-
-# Create your tests here.
 
 
 class NoteTestCase(TestCase):
 
     fixtures = ['routes.json']
 
-    def setUp(self):
-        self.client = ClientFactory()
-        self.admin = User.objects.create(username="admin")
-        self.note = NoteFactory.create(client=self.client, author=self.admin)
+    @classmethod
+    def setUpTestData(cls):
+        cls.clients = ClientFactory()
+        cls.admin = User.objects.create(username="admin")
+        cls.note = NoteFactory.create(client=cls.clients, author=cls.admin)
 
     def test_attach_note_to_member(self):
         """Create a note attached to a member"""
         note = self.note
-        self.assertEqual(self.client, note.client)
+        self.assertEqual(self.clients, note.client)
         self.assertEqual(self.admin, note.author)
 
     def test_mark_as_read(self):
@@ -41,7 +39,7 @@ class NoteTestCase(TestCase):
     def test_str_includes_note(self):
         """An note listing must include the note text"""
         note = Note.objects.create(
-            client=self.client,
+            client=self.clients,
             author=self.admin,
             note='x123y'
         )

--- a/django/santropolFeast/page/tests.py
+++ b/django/santropolFeast/page/tests.py
@@ -42,6 +42,3 @@ class HomeViewTestCase(TestCase):
             reverse('page:login') + '?next=/p/home',
             status_code=302
         )
-
-    def tearDown(self):
-        self.client.logout()


### PR DESCRIPTION
*Fixes # .*

### Changes proposed in this pull request:

* Changes in the tests to use setUpTestData() to load data shared by all tests cases, and use setUp() to login the client per tests case.

Ref: http://stackoverflow.com/questions/29428894/django-setuptestdata-vs-setup

### Status

- [X] READY


### Deployment notes and migration

- [ ] Migration needed

Fill me in ...

@savoirfairelinux/mll

…l the


