### PR TITLE
Allow to use the same client as billing information

### DIFF
--- a/django/santropolFeast/member/factories.py
+++ b/django/santropolFeast/member/factories.py
@@ -86,8 +86,8 @@ class ClientFactory (factory.DjangoModelFactory):
     )
     birthdate = factory.Faker('date')
     route = factory.LazyAttribute(
-            lambda x: random.choice(Route.objects.all())
-        )
+        lambda x: random.choice(Route.objects.all())
+    )
 
     meal_default_week = factory.LazyAttribute(lambda x: generate_json())
 

--- a/django/santropolFeast/member/forms.py
+++ b/django/santropolFeast/member/forms.py
@@ -124,7 +124,7 @@ class ClientAddressInformation(forms.Form):
             'rows': 2,
             'placeholder': _('Delivery Note here ...')
         })
-        )
+    )
 
 
 class ClientRestrictionsInformation(forms.Form):
@@ -235,6 +235,11 @@ class MemberForm(forms.Form):
 
     def clean(self):
         cleaned_data = super(MemberForm, self).clean()
+
+        """If the client pays for himself. """
+        if cleaned_data.get('same_as_client') is True:
+            return cleaned_data
+
         member = cleaned_data.get('member')
         firstname = cleaned_data.get('firstname')
         lastname = cleaned_data.get('lastname')
@@ -284,6 +289,15 @@ class ClientPaymentInformation(MemberForm):
         widget=forms.Select(attrs={'class': 'ui dropdown'})
     )
 
+    same_as_client = forms.BooleanField(
+        label=_("Same As Client"),
+        initial=True,
+        required=False,
+        help_text=_('If checked, the personal information \
+            of the client will be used as billing information.'),
+        widget=forms.CheckboxInput(
+            attrs={}))
+
     billing_payment_type = forms.ChoiceField(
         label=_("Payment Type"),
         choices=PAYMENT_TYPE,
@@ -308,6 +322,10 @@ class ClientPaymentInformation(MemberForm):
 
     def clean(self):
         cleaned_data = super(ClientPaymentInformation, self).clean()
+
+        if cleaned_data.get('same_as_client') is True:
+            return cleaned_data
+
         member = cleaned_data.get('member')
         if member:
             member_id = member.split(' ')[0].replace('[', '').replace(']', '')

--- a/django/santropolFeast/member/management/commands/createclients.py
+++ b/django/santropolFeast/member/management/commands/createclients.py
@@ -12,7 +12,7 @@ class Command(BaseCommand):
         # Load fixtures for the routes
         fixture_dir = os.path.abspath(os.path.join(
             os.path.dirname(__file__), '../fixtures')
-                                      )
+        )
         fixture_filename = 'routes.json'
         fixture_file = os.path.join(fixture_dir, fixture_filename)
         call_command('loaddata', fixture_filename)

--- a/django/santropolFeast/member/templates/forms/form.html
+++ b/django/santropolFeast/member/templates/forms/form.html
@@ -132,6 +132,19 @@
         }
       });
 
+      var same_as_client = document.getElementById('id_payment_information-same_as_client')
+      // Initial state
+      if (same_as_client && same_as_client.checked) {
+          $('#billing_select_member').hide();
+      }
+      $("#id_payment_information-same_as_client").on("change", function() {
+          if (this.checked) {
+              $('#billing_select_member').hide();
+          } else {
+              $('#billing_select_member').show();
+          }
+      });
+
       $('#wizard_form_birthdate').calendar({
         type: 'date',
         formatter: {

--- a/django/santropolFeast/member/templates/forms/steps/payment_information.html
+++ b/django/santropolFeast/member/templates/forms/steps/payment_information.html
@@ -1,6 +1,16 @@
 <h4 class="ui dividing header">{{ _('Billing information') }}</h4>
 
-<div class="ui center aligned basic segment">
+<div class="field">
+    <div class="ui toggle checkbox">
+      {{wizard.form.same_as_client}}
+      <label>
+          {{wizard.form.same_as_client.label}}
+          <i class="help-text question yellow icon link" data-content="{{ wizard.form.same_as_client.help_text }}"></i>
+      </label>
+    </div>
+</div>
+
+<div class="ui center aligned basic segment" id="billing_select_member">
   <div class="ui fluid category search">
     <div class="ui icon input">
       {{wizard.form.member}}

--- a/django/santropolFeast/member/tests.py
+++ b/django/santropolFeast/member/tests.py
@@ -498,6 +498,7 @@ class FormTestCase(TestCase):
 
         payment_information_data = {
             "client_wizard-current_step": "payment_information",
+            "payment_information-same_as_client": False,
             "payment_information-firstname": "Billing",
             "payment_information-lastname": "Testing",
             "payment_information-billing_payment_type": "check",
@@ -536,7 +537,7 @@ class FormTestCase(TestCase):
         ]
 
         for step, data in stepsdata:
-            self.client.post(
+            response = self.client.post(
                 reverse_lazy('member:member_step', kwargs={'step': step}),
                 data,
                 follow=True
@@ -696,14 +697,9 @@ class FormTestCase(TestCase):
 
         payment_information_data = {
             "client_wizard-current_step": "payment_information",
-            "payment_information-firstname": "Same",
-            "payment_information-lastname": "User",
+            "payment_information-same_as_client": True,
             "payment_information-billing_payment_type": "check",
             "payment_information-facturation": "default",
-            "payment_information-street": "8686 rue clark",
-            "payment_information-apartement": "86",
-            "payment_information-city": "Montreal",
-            "payment_information-postal_code": "H8C6G8",
             "address_information-latitude": 0.0,
             "address_information-longitude": 0.0,
             "address_information-distance": 0.0,
@@ -819,7 +815,7 @@ class FormTestCase(TestCase):
             "Testing referral reason"
         )
 
-        # test client member is billint member
+        # test client member is billing member
         self.assertEqual(client.member.id, client.billing_member.id)
 
         # test_billing_name:

--- a/django/santropolFeast/member/views.py
+++ b/django/santropolFeast/member/views.py
@@ -120,40 +120,44 @@ class ClientWizard(NamedUrlSessionWizardView):
         return member
 
     def save_billing_member(self, member):
-        payment_information = self.form_dict['payment_information']
-        e_b_member = payment_information.cleaned_data.get('member')
-        if self.billing_member_is_member():
-            billing_member = member
-        elif e_b_member:
-            e_b_member_id = e_b_member.split(' ')[0].\
-                replace('[', '').replace(']', '')
-            billing_member = Member.objects.get(pk=e_b_member_id)
-        else:
-            billing_address = Address.objects.create(
-                number=payment_information.cleaned_data.get('number'),
-                street=payment_information.cleaned_data.get('street'),
-                apartment=payment_information.cleaned_data.get('apartment'),
-                floor=payment_information.cleaned_data.get('floor'),
-                city=payment_information.cleaned_data.get('city'),
-                postal_code=payment_information.cleaned_data.get(
-                    'postal_code'
-                ),
-            )
-            billing_address.save()
+        payment_information = \
+            self.form_dict['payment_information'].cleaned_data
 
-            billing_member = Member.objects.create(
-                firstname=payment_information.cleaned_data.get('firstname'),
-                lastname=payment_information.cleaned_data.get('lastname'),
-                address=billing_address,
-            )
-            billing_member.save()
+        if payment_information.get('same_as_client'):
+            billing_member = member
+
+        else:
+            e_b_member = payment_information.get('member')
+            if self.billing_member_is_member():
+                billing_member = member
+            elif e_b_member:
+                e_b_member_id = e_b_member.split(' ')[0].\
+                    replace('[', '').replace(']', '')
+                billing_member = Member.objects.get(pk=e_b_member_id)
+            else:
+                billing_address = Address.objects.create(
+                    number=payment_information.get('number'),
+                    street=payment_information.get('street'),
+                    apartment=payment_information.get('apartment'),
+                    floor=payment_information.get('floor'),
+                    city=payment_information.get('city'),
+                    postal_code=payment_information.get('postal_code'),
+                )
+                billing_address.save()
+
+                billing_member = Member.objects.create(
+                    firstname=payment_information.get('firstname'),
+                    lastname=payment_information.get('lastname'),
+                    address=billing_address,
+                )
+                billing_member.save()
 
         return billing_member
 
     def save_emergency_contact(self, billing_member):
         emergency_contact = self.form_dict['emergency_contact']
         e_emergency_member = emergency_contact.cleaned_data.get('member')
-        if self.billing_member_is_emergency_contact():
+        if self.billing_member_is_emergency_contact(billing_member):
             emergency = billing_member
         elif e_emergency_member:
             e_emergency_member_id = e_emergency_member.split(' ')[0]\
@@ -257,18 +261,16 @@ class ClientWizard(NamedUrlSessionWizardView):
             return True
         return False
 
-    def billing_member_is_emergency_contact(self):
+    def billing_member_is_emergency_contact(self, billing_member):
         emergency_contact = self.form_dict['emergency_contact']
-        payment_information = self.form_dict['payment_information']
 
         e_firstname = emergency_contact.cleaned_data.get('firstname')
         e_lastname = emergency_contact.cleaned_data.get('lastname')
 
-        p_firstname = payment_information.cleaned_data.get('firstname')
-        p_lastname = payment_information.cleaned_data.get('lastname')
-
-        if e_firstname == p_firstname and e_lastname == p_lastname:
+        if e_firstname == billing_member.firstname \
+                and e_lastname == billing_member.lastname:
             return True
+
         return False
 
     def referent_is_emergency_contact(self):


### PR DESCRIPTION
*Fixes #319 .*

### Changes proposed in this pull request:

* Allow to use the client information as billing information
* Adapt unit tests related to the form
* Lighten code syntax in views.py

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

@savoirfairelinux/mll

Issue #319