### PR TITLE
Make the steps clickable in the client creation form

### DIFF
--- a/django/santropolFeast/member/templates/forms/form.html
+++ b/django/santropolFeast/member/templates/forms/form.html
@@ -1,4 +1,4 @@
-{% extends "base_member.html" %}
+{% extends "base.html" %}
 
 {% load i18n %}
 {% load staticfiles %}
@@ -19,96 +19,58 @@
 {% block title %}Create a new client{% endblock %}
 
 {% block message %}
-<div class="ui message">
-  <div class="header">
-  Welcome to the client creation form
-  </div>
-  <p>Fill out the form below to create a new client. No information will be saved until all the steps are completed.</p>
+<div class="ui text container">
+    <div class="ui warning small message">
+        <div class="header">Notice</div>
+        <p>No information will be saved until all the steps are completed.</p>
+    </div>
 </div>
 {% endblock %}
 
 {% block content %}
 
 <div class="ui secondary pointing fluid menu">
-  <h2 class="ui header">New Client</h2>
+    <h1 class="ui header">New Client</h1>
 </div>
 
-  <div class="six wide column">
+<div class="six wide column">
     <div class="ui vertical steps">
-
-      {% include 'forms/step.html' with step=1 icon='male' name=_('Personal') description=_('First name, last name, ...') %}
-
-      {% include 'forms/step.html' with step=2 icon='home' name=_('Address') description=_('Street number, city, ...') %}
-
-      {% include 'forms/step.html' with step=3 icon='treatment' name=_('Referent') description=_('Referent contact information') %}
-
-      {% include 'forms/step.html' with step=4 icon='payment' name=_('Payment') description=_('Payment method, card, ...') %}
-
-      {% include 'forms/step.html' with step=5 icon='food' name=_('Preferences') description=_('Deliveries, restrictions, ...') %}
-
-      {% include 'forms/step.html' with step=6 icon='first aid' name=_('Emergency') description=_('Emergency contact information') %}
-
+        {% include 'forms/step.html' with step=1 url='basic_information' icon='male' name=_('Personal') description=_('First name, last name, ...') %}
+        {% include 'forms/step.html' with step=2 url='address_information' icon='home' name=_('Address') description=_('Street number, city, ...') %}
+        {% include 'forms/step.html' with step=3 url='referent_information' icon='treatment' name=_('Referent') description=_('Referent contact information') %}
+        {% include 'forms/step.html' with step=4 url='payment_information' icon='payment' name=_('Payment') description=_('Payment method, card, ...') %}
+        {% include 'forms/step.html' with step=5 url='dietary_restriction' icon='food' name=_('Preferences') description=_('Deliveries, restrictions, ...') %}
+        {% include 'forms/step.html' with step=6 url='emergency_contact' icon='first aid' name=_('Emergency') description=_('Emergency contact information') %}
     </div>
-  </div>
+ </div>
 
-    <div class="ten wide column form-steps">
-      <form action="" method="post" class="ui form error">{% csrf_token %}
+<div class="ten wide column form-steps">
+    <form action="" method="post" class="ui form error">{% csrf_token %}
         {% if wizard.form.errors %}
         <div class="ui error message">
-          <div class="header">{{ _('Required information missing')}}</div>
-          <p>{{ _('Please review the form to make sure that all required fields are filled.')}}</p>
-          {{ wizard.form.errors }}
+            <div class="header">{{ _('Required information missing')}}</div>
+            <p>{{ _('Please review the form to make sure that all required fields are filled.')}}</p>
+            {{ wizard.form.errors }}
         </div>
         {% endif %}
+
         {{wizard.management_form}}
 
-        {% if wizard.form.forms %}
-
-          {{wizard.form.management_form}}
-
-          {% for form in wizard.form.forms}
-            <div class="ui small icon input">
-              sdfsfdsf
-            </div>
-
-        {% else %}
-          {% if wizard.steps.current == 'basic_information' %}
-            {% include 'forms/steps/basic_information.html' %}
-          {% elif wizard.steps.current == 'address_information' %}
-            {% include 'forms/steps/address_information.html' %}
-          {% elif wizard.steps.current == 'referent_information' %}
-            {% include 'forms/steps/referent_information.html' %}
-          {% elif wizard.steps.current == 'payment_information' %}
-            {% include 'forms/steps/payment_information.html' %}
-          {% elif wizard.steps.current == 'dietary_restriction' %}
-            {% include 'forms/steps/dietary_restriction.html' %}
-          {% elif wizard.steps.current == 'emergency_contact' %}
-            {% include 'forms/steps/emergency_contact.html' %}
-          {% else %}
-
-            {% for form in wizard.form %}
-
-            <div class="field {% if form.errors %} error {% endif %}">
-              <label>{{ form.label }} ({{form.name}})</label>
-              {{ form }}
-            </div>
-          {% endfor %}
-
-          {% endif %}
-
-        {% endif %}
+        {% include 'forms/steps/'|add:wizard.steps.current|add:'.html' %}
 
         {% if wizard.steps.prev %}
         <button class="ui left floated button" name="wizard_goto_step" type="submit" value="{{wizard.steps.prev}}">
-          {% trans "Back"%}
+            {% trans "Back"%}
         </button>
         {% endif %}
+
         {% if wizard.steps.step1 == 6 %}
-          <input class="big ui right floated yellow button" type="submit" value="Save"/>
+            <input class="big ui right floated yellow button" type="submit" value="Save"/>
         {% else %}
-          <button  class="big ui yellow right floated button" name="wizard_goto_step" type="submit">Next</button>
+            <button  class="big ui yellow right floated button" name="wizard_goto_step" type="submit">Next</button>
         {% endif %}
-      </form>
+
+    </form>
 </div>
 {% endblock %}
 

--- a/django/santropolFeast/member/templates/forms/step.html
+++ b/django/santropolFeast/member/templates/forms/step.html
@@ -1,13 +1,13 @@
 {% if wizard.steps.step1 == step  %}
-<div class="step active">
+<a class="step active" href="{% url 'member:member_step' step=url %}">
 {% elif wizard.steps.step1 > step %}
-<div class="completed step">
+<a class="completed step link" href="{% url 'member:member_step' step=url %}">
 {% else %}
-<div class="link step">
+<a class="disabled step">
 {% endif %}
     <i class="{{icon}} icon"></i>
     <div class="content">
         <div class="title">{{ name }}</div>
         <div class="description">{{ description }}</div>
     </div>
-</div>
+</a>

--- a/django/santropolFeast/member/templates/forms/steps/address_information.html
+++ b/django/santropolFeast/member/templates/forms/steps/address_information.html
@@ -1,10 +1,3 @@
-<div class="ui attached message">
-    <div class="header">
-    Address information
-    </div>
-    <p>Fill out the form below</p>
-</div>
-
 <h4 class="ui dividing header">{{ _('Address information') }}</h4>
 
 <div class="field">

--- a/django/santropolFeast/member/templates/forms/steps/referent_information.html
+++ b/django/santropolFeast/member/templates/forms/steps/referent_information.html
@@ -1,12 +1,4 @@
-<div class="ui attached message">
-    <div class="header">
-    Referral information
-    </div>
-    <p>Fill out the form below to create a new client</p>
-</div>
-
 <h4 class="ui dividing header">{{ _('Identity') }}</h4>
-
 
 <div class="ui center aligned basic segment">
   <div class="ui fluid category search">


### PR DESCRIPTION
*Fixes #329  .*

### Changes proposed in this pull request:

* Make all the steps clickable, except the disabled ones
* Clean up form.py template
* Improve system message

### Status

- [X] READY

@savoirfairelinux/mll

Issue #329