### PR TITLE
Remove frontend network and use the default one instead.

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -16,5 +16,4 @@ services:
     depends_on:
       - web
     networks:
-      - frontend
       - backend

--- a/docker-compose.travis.yml
+++ b/docker-compose.travis.yml
@@ -19,5 +19,4 @@ services:
     depends_on:
       - web
     networks:
-      - frontend
       - backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,5 +27,4 @@ volumes:
   souschef_static:
 
 networks:
-  frontend:
   backend:


### PR DESCRIPTION
Ref: issues 830

## Fixes #830 

### Changes proposed in this pull request:

* Remove not needed frontend network in favor of the default one.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Manually spawn into one of the docker containers and verify that you don't get this warning
`WARNING: Some networks were defined but are not used by any service: frontend`