### PR TITLE
Remove deprecated method argument 

### DIFF
--- a/src/order/models.py
+++ b/src/order/models.py
@@ -203,7 +203,20 @@ class OrderManager(models.Manager):
         return created_orders
 
     def create_batch_orders(self, delivery_dates, client, items,
-                            override_dates=[], return_created_orders=False):
+                            override_dates=[]):
+        """
+        Create orders for one or multiple days, for a given client.
+        Order items will be created based on client's meals schedule.
+
+        Parameters:
+          delivery_dates : dates on which orders are to be created
+          client : a client object
+          items: the order items
+          override_dates: dates on which existing orders can be overriden
+
+        Returns:
+          An array of created orders.
+        """
         created_orders = []
         messages = []
 
@@ -238,10 +251,7 @@ class OrderManager(models.Manager):
             )
             created_orders.append(order)
 
-        if not return_created_orders:
-            return len(created_orders)   # LXYANG: TO BE DEPRECATED
-        else:
-            return created_orders
+        return created_orders
 
     @transaction.atomic
     def create_order(self, delivery_date, client, items, prices):

--- a/src/order/tests.py
+++ b/src/order/tests.py
@@ -614,9 +614,9 @@ class OrderCreateBatchTestCase(SousChefTestMixin, TestCase):
         Provide a client, 4 delivery dates.
         """
         client = self.episodic_client[0]
-        counter = Order.objects.create_batch_orders(
+        created_orders = Order.objects.create_batch_orders(
             self.delivery_dates, self.episodic_client[0], self.orditems)
-        self.assertEqual(counter, 4)
+        self.assertEqual(len(created_orders), 4)
 
         # check items
         # 2016-12-12

--- a/src/order/views.py
+++ b/src/order/views.py
@@ -249,8 +249,7 @@ class CreateOrdersBatch(
 
         # Place orders using posted datas
         created_orders = Order.objects.create_batch_orders(
-            del_dates, client, items, override_dates=ovr_dates,
-            return_created_orders=True
+            del_dates, client, items, override_dates=ovr_dates
         )
 
         # check created and uncreated dates


### PR DESCRIPTION
## Tackles #842

### Changes proposed in this pull request:

* Remove deprecated argument
* Update method documenation

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

`create_batch_orders` is only called once outside of tests, with the argument as true. There is no change in behaviour.
