### PR TITLE
Flush unused methods and tests

### DIFF
--- a/src/delivery/tests.py
+++ b/src/delivery/tests.py
@@ -156,58 +156,6 @@ class KitchenCountReportTestCase(SousChefTestMixin, TestCase):
         response = self.client.get('/delivery/viewDownloadKitchenCount/')
         self.assertTrue('ReportLab' in repr(response.content))
 
-    def test_extra_similar_side_dishes(self):
-        """Test cumulative quantities for similar side dishes."""
-        # generate orders today
-        self.today = datetime.date.today()
-        clients = Client.active.all()
-        numorders = Order.objects.auto_create_orders(
-            self.today, clients)
-        Menu.create_menu_and_components(
-            self.today,
-            ['Ginger pork',
-             'Green Salad', 'Fruit Salad',
-             'Day s Dessert', 'Day s Diabetic Dessert',
-             'Day s Pudding', 'Day s Compote'])
-
-        # main dish and its ingredients today
-        main_dishes = Component.objects.filter(name='Ginger pork')
-        main_dish = main_dishes[0]
-        dish_ingredients = Component.get_recipe_ingredients(
-            main_dish.id)
-        for ing in dish_ingredients:
-            ci = Component_ingredient(
-                component=main_dish,
-                ingredient=ing,
-                date=self.today)
-            ci.save()
-        # Add sides ingredient
-        sides_component = Component.objects.get(
-            component_group=COMPONENT_GROUP_CHOICES_SIDES)
-        sides_ingredient = Ingredient.objects.get(name='Brussel sprouts')
-        ci = Component_ingredient(
-            component=sides_component,
-            ingredient=sides_ingredient,
-            date=self.today)
-        ci.save()
-
-        # Add two separate extra compote order items for 'Tracy'
-        member = Member.objects.filter(lastname='Tracy')[0]
-        client = Client.objects.get(member=member.id)
-        order = Order.objects.get(client=client.id, delivery_date=self.today)
-        order.add_item(
-            'meal_component',
-            component_group='compote',
-            total_quantity=1,
-            remark='no sugar')
-        order.add_item(
-            'meal_component',
-            component_group='compote',
-            total_quantity=1,
-            remark='no sugar')
-        response = self.client.get('/delivery/kitchen_count/')
-        self.assertTrue(b'Compote' in response.content)
-
 
 class ChooseDayMainDishIngredientsTestCase(SousChefTestMixin, TestCase):
 
@@ -458,16 +406,6 @@ class DeliveryRouteSheetTestCase(SousChefTestMixin, TestCase):
         member = Member.objects.filter(lastname='Tracy')[0]
         client = Client.objects.get(member=member.id)
         order = Order.objects.get(client=client.id, delivery_date=self.today)
-        order.add_item(
-            'meal_component',
-            component_group='compote',
-            total_quantity=1,
-            remark='no sugar')
-        order.add_item(
-            'meal_component',
-            component_group='compote',
-            total_quantity=1,
-            remark='no sugar')
         mile_end_id = Route.objects.get(name='Mile-End').id
         route_list = Order.get_delivery_list(self.today, mile_end_id)
         self.assertTrue('Tracy' in repr(route_list))

--- a/src/order/models.py
+++ b/src/order/models.py
@@ -390,36 +390,6 @@ class Order(models.Model):
             if x.order_item_type == 'meal_component' or x.component_group
         ])
 
-    def add_item(self, type, **kwargs):
-        """
-        Add a new item to the given order.
-        """
-        quantity = kwargs.get('total_quantity', 1)
-        billable = kwargs.get('billable', True)
-        Order_item.objects.create(
-            order=self,
-            component_group=kwargs.get('component_group', ''),
-            price=quantity * MAIN_PRICE_DEFAULT if billable else 0,
-            billable_flag=billable,
-            size=kwargs.get('size', 'R'),
-            order_item_type=type,
-            total_quantity=quantity,
-            remark=kwargs.get('remark', ''))
-
-    def remove_item(self, order_item_id):
-        """
-        Remove an existing item from the order.
-        """
-        self.orders.remove(order_item_id)
-
-    def cancel(self):
-        """
-        Cancel the given order.
-        """
-        # 'C' = Cancelled
-        self.status = 'C'
-        self.save()
-
     def __str__(self):
         return "client={}, delivery_date={}".format(
             self.client,

--- a/src/order/tests.py
+++ b/src/order/tests.py
@@ -39,35 +39,6 @@ class OrderTestCase(TestCase):
         """
         cls.order = OrderFactory(order_item=None)
 
-    def test_order_add_item_meal_component(self):
-        """
-        Add a billable meal component item to an order.
-        """
-        self.order.add_item(
-            'B component',
-            component_group='main_dish',
-            total_quantity=2,
-            size='L')
-        self.assertEqual(1, self.order.orders.count())
-        item = self.order.orders.filter(order_item_type='B component').get()
-        self.assertTrue(item.billable_flag)
-        self.assertEqual(item.component_group, 'main_dish')
-        self.assertEqual(item.total_quantity, 2)
-        self.assertEqual(item.size, 'L')
-        self.assertEqual(item.price, MAIN_PRICE_DEFAULT * 2)
-
-    def test_order_add_item_visit(self):
-        """
-        Add a non-billable visit item to an order.
-        """
-        self.order.add_item('N delivery',
-                            billable=False)
-        self.assertEqual(1, self.order.orders.count())
-        item = self.order.orders.filter(order_item_type='N delivery').get()
-        self.assertFalse(item.billable_flag)
-        self.assertEqual(item.total_quantity, 1)
-        self.assertEqual(item.price, 0)
-
 
 class OrderManagerTestCase(TestCase):
 


### PR DESCRIPTION
## Tackles #842 

It turns out that `add_item` is not used, so the clients are always billed with the proper prices. It must have been part of a refactoring initiative that did not finish. 

### Changes proposed in this pull request:

🔥 

* Remove `add_item`, `remove_item` and `cancel` methods
* Remove corresponding test cases. `remove_item` and `cancel` were not tested.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### Additional notes

I let you decide if you want to merge that or not. In my opinion, it's better to remove dead code, as it can lead to confusion.