### PR TITLE
Billings should be ordered by year, month descending

### DIFF
--- a/src/billing/models.py
+++ b/src/billing/models.py
@@ -68,7 +68,7 @@ class BillingManager(models.Manager):
 class Billing(models.Model):
 
     class Meta:
-        ordering = ["billing_year", "-billing_month"]
+        ordering = ["-billing_year", "-billing_month"]
 
     total_amount = models.DecimalField(
         verbose_name=_('total_amount'),


### PR DESCRIPTION
Fixes #849: Billings should be displayed in descending year, month order
