### PR TITLE
In order creation form only active clients should be displayed

### DIFF
--- a/src/order/forms.py
+++ b/src/order/forms.py
@@ -64,12 +64,12 @@ class CreateOrdersBatchForm(forms.Form):
         required=True,
         label=_('Client'),
         widget=forms.Select(attrs={'class': 'ui search dropdown'}),
-        queryset=Client.objects.all().select_related(
+        queryset=Client.active.select_related(
             'member'
         ).only(
             'member__firstname',
             'member__lastname'
-        )
+        ).order_by('member__lastname')
     )
 
     delivery_dates = forms.CharField(


### PR DESCRIPTION
Fixes #846: Client drop-list in Place orders should only display ACTIVE clients.

Also display the clients sorted by last name.
